### PR TITLE
fix(litellm): stop reasoning_effort being a silent no-op on OpenRouter routes

### DIFF
--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -110,14 +110,25 @@
 # `UnsupportedParamsError` (HTTP 500) instead. It trades a silent no-op
 # for loud request failures.
 #
-# OFF OPENROUTER, `model_info` IS NOT THE FIX. `supports_reasoning` is
-# read only by `OpenrouterConfig`; other providers answer from a static
-# list (e.g. `TogetherAIConfig` subtracts from `OpenAIGPTConfig`'s base
-# list, which carries no `reasoning_effort` at all). Setting the flag on
-# a `together_ai/*` row changes nothing and the parameter is still
-# popped silently — so confirm the provider's chat config advertises
-# `reasoning_effort` before setting it. Most OpenAI-compatible ones do
-# not. The CI guard tracks this separately from the OpenRouter case.
+# THIS IS NOT AN OPENROUTER-ONLY TRAP, and `model_info` is not an
+# OpenRouter-only fix. Verified at litellm 1.86.2, nine other provider
+# configs gate a reasoning knob on the same `litellm.supports_reasoning`
+# call, fail-closed in the same way: `groq`, `xai`, `deepinfra`,
+# `cerebras`, `fireworks_ai`, `perplexity` and `bedrock_mantle` gate
+# `reasoning_effort`; `zai` and `minimax` gate `thinking` (and never
+# advertise `reasoning_effort` at all). On all of them form 1 works,
+# because LiteLLM registers `model_info` into its model-cost map under
+# the raw `litellm_params.model` string whatever the provider.
+#
+# Where `model_info` really is a placebo is a provider whose chat config
+# never consults `supports_reasoning` — e.g. `TogetherAIConfig`, which
+# only subtracts from `OpenAIGPTConfig`'s base list, and that base list
+# carries no reasoning knob at all. On a `together_ai/*` row the
+# parameter is popped silently whatever you set. So: check the
+# provider's `get_supported_openai_params` before setting the knob, and
+# note that the answer is per-knob, not per-provider. The CI guard
+# tracks the two cases separately (see the provider tables in
+# tests/config/test_litellm_template.py).
 #
 # VERIFY, don't assume: the `cost_callback` logs `request_params` per
 # call, read from LiteLLM's post-mapping params — i.e. what the wire

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -50,14 +50,14 @@
 #
 # ## reasoning_effort is silently dropped unless the model is flagged
 #
-# `litellm_params.reasoning_effort` reaches the wire only when LiteLLM
-# believes the model is reasoning-capable.
+# On `openrouter/*` routes, `litellm_params.reasoning_effort` reaches
+# the wire only when LiteLLM believes the model is reasoning-capable.
 # `OpenrouterConfig.get_supported_openai_params` advertises
-# `reasoning_effort` / `thinking` only if
-# `litellm.supports_reasoning(model)` is true, and that reads LiteLLM's
-# built-in model-cost map. A model ABSENT from that map answers False —
-# so the gate fails closed, and `drop_params: true` then discards the
-# parameter with no error and no log line.
+# `reasoning_effort` / `thinking` — both under the same condition — only
+# if `litellm.supports_reasoning(model)` is true, and that reads
+# LiteLLM's built-in model-cost map. A model ABSENT from that map
+# answers False — so the gate fails closed, and `drop_params: true` then
+# discards the parameter with no error and no log line.
 #
 # Absent is the NORMAL state for an OpenRouter slug: verified against
 # the pinned litellm 1.86.2, `qwen/qwen3-max` and
@@ -71,7 +71,9 @@
 # Two forms that DO reach the wire (both verified against 1.86.2):
 #
 #   1. Flag the model, then set the param. `model_info` is a sibling of
-#      `litellm_params`, not a key inside it:
+#      `litellm_params`, not a key inside it — and like `litellm_params`
+#      it must be mirrored onto the paired `[1m]` row, or probes and
+#      real traffic run at different reasoning depths:
 #
 #        - model_name: my-model
 #          litellm_params:
@@ -81,12 +83,21 @@
 #            reasoning_effort: high
 #          model_info:
 #            supports_reasoning: true    # REQUIRED, else the line above is a no-op
+#        - model_name: my-model[1m]      # paired alias — see #2832 below
+#          litellm_params:
+#            model: openrouter/vendor/my-model
+#            api_key: os.environ/OPENROUTER_API_KEY
+#            drop_params: true
+#            reasoning_effort: high
+#          model_info:
+#            supports_reasoning: true
 #
 #      This is enforced in CI by tests/config/test_litellm_template.py
 #      for entries in this template.
 #
 #   2. Bypass the mapper with OpenRouter's native shape, which does not
-#      consult the model map at all (see the qwen3-max entry below):
+#      consult the model map at all (see the qwen3-max entry below).
+#      This goes inside `litellm_params`, on BOTH rows:
 #
 #        extra_body:
 #          reasoning:
@@ -94,13 +105,28 @@
 #
 # Do NOT reach for `drop_params: false` to force it through. That flag
 # is what stops Anthropic-only fields LiteLLM cannot translate (e.g.
-# `thinking`) from 400ing tool-heavy turns; turning it off trades a
-# silent no-op for loud request failures.
+# `thinking`) from 400ing tool-heavy turns; turning it off does not pass
+# the parameter through either — `_check_valid_arg` raises
+# `UnsupportedParamsError` (HTTP 500) instead. It trades a silent no-op
+# for loud request failures.
+#
+# OFF OPENROUTER, `model_info` IS NOT THE FIX. `supports_reasoning` is
+# read only by `OpenrouterConfig`; other providers answer from a static
+# list (e.g. `TogetherAIConfig` subtracts from `OpenAIGPTConfig`'s base
+# list, which carries no `reasoning_effort` at all). Setting the flag on
+# a `together_ai/*` row changes nothing and the parameter is still
+# popped silently — so confirm the provider's chat config advertises
+# `reasoning_effort` before setting it. Most OpenAI-compatible ones do
+# not. The CI guard tracks this separately from the OpenRouter case.
 #
 # VERIFY, don't assume: the `cost_callback` logs `request_params` per
 # call, read from LiteLLM's post-mapping params — i.e. what the wire
-# actually carried (#3611). If `reasoning_effort` does not appear there
-# on real agent traffic, it was dropped, whatever this file says.
+# actually carried (#3611). Which key to grep for depends on the form:
+# form 1 shows up as `reasoning_effort`, form 2 as `reasoning` (the
+# callback hoists it out of `extra_body` to the flat level, so a working
+# form-2 route logs `"reasoning": {"effort": "high"}` and NEVER logs
+# `reasoning_effort`). Neither key present on real agent traffic means
+# it was dropped, whatever this file says.
 #
 # Whatever you set here (or leave unset), the bundled `cost_callback`
 # records the sampling config each call actually ran under as
@@ -171,12 +197,14 @@ data:
       # context compaction-math opt-in via
       # `ANTHROPIC_CUSTOM_MODEL_OPTION`; from LiteLLM's side it's
       # just a routing alias pointing at the same backend. Keep the
-      # `litellm_params` block identical to the bare row (the CI guard
-      # in tests/config/test_litellm_template.py compares them as parsed
-      # YAML): if you change any tuning above (`drop_params`, the
-      # `extra_body` provider pin / reasoning), mirror it here too.
-      # Divergence between the two rows means probes and real requests
-      # are quietly served by different configs.
+      # `litellm_params` AND `model_info` blocks identical to the bare
+      # row (the CI guard in tests/config/test_litellm_template.py
+      # compares both as parsed YAML): if you change any tuning above
+      # (`drop_params`, the `extra_body` provider pin / reasoning, or
+      # `model_info.supports_reasoning`), mirror it here too. Divergence
+      # between the two rows means probes and real requests are quietly
+      # served by different configs — for `model_info` specifically, at
+      # different reasoning depths.
       - model_name: qwen3-max[1m]
         litellm_params:
           model: openrouter/qwen/qwen3-max

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -70,7 +70,8 @@
 # no-op: the agent runs at the provider's default depth and nothing
 # anywhere says so.
 #
-# Two forms that DO reach the wire (both verified against 1.86.2):
+# Two forms that DO reach the wire (both verified against 1.86.2).
+# PREFER FORM 2 — see the caveat under form 1.
 #
 #   1. Flag the model, then set the param. `model_info` is a sibling of
 #      `litellm_params`, not a key inside it — and like `litellm_params`
@@ -97,6 +98,22 @@
 #      This is enforced in CI by tests/config/test_litellm_template.py
 #      for entries in this template.
 #
+#      CAVEAT: this only gets the param past LiteLLM. It sends the
+#      OpenAI-style `reasoning_effort`, which not every OpenRouter
+#      endpoint accepts — the flag asserts "LiteLLM, stop dropping
+#      this", not "the provider honours it". Check the model's real
+#      capabilities before relying on it:
+#
+#        curl -s https://openrouter.ai/api/v1/models/<vendor>/<slug>/endpoints \
+#          | jq '.data.endpoints[] | {provider: .provider_name, params: .supported_parameters}'
+#
+#      Verified 2026-07-25: every one of glm-5.2's 33 endpoints lists
+#      BOTH `reasoning` and `reasoning_effort`, but poolside/laguna-s-2.1
+#      (sole endpoint) lists `reasoning` and `include_reasoning` and NOT
+#      `reasoning_effort`. Support is per-model AND per-endpoint, so with
+#      a `provider.order` pin what matters is the endpoint you pinned,
+#      not the model-level union that `/api/v1/models` reports.
+#
 #   2. Bypass the mapper with OpenRouter's native shape, which does not
 #      consult the model map at all (see the qwen3-max entry below).
 #      This goes inside `litellm_params`, on BOTH rows:
@@ -104,6 +121,10 @@
 #        extra_body:
 #          reasoning:
 #            effort: "high"
+#
+#      Preferred: `reasoning` is the parameter OpenRouter itself
+#      documents, and in the sample above it is supported everywhere
+#      `reasoning_effort` is, plus on endpoints where it is not.
 #
 # Do NOT reach for `drop_params: false` to force it through. That flag
 # is what stops Anthropic-only fields LiteLLM cannot translate (e.g.

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -141,13 +141,37 @@
 #     `bedrock_converse` while the only prefix you can write is
 #     `bedrock/`. There is no third spelling that makes the two meet.
 #
-# On those routes the knob reaches the wire only if the provider config's
-# own model-name heuristics recognise the name (`claude-3-7`,
-# `claude-sonnet-4`, `claude-opus-4`, `deepseek.r1`, `gpt-oss`, Nova 2 on
-# bedrock; a "claude" name on github_copilot) — nothing in this file
-# changes that. Use the provider's native request shape, or verify
+# "`model_info` can't rescue it" is NOT "it can't work", though — two
+# other things still put the knob on the wire on those routes, and the CI
+# guard accepts both rather than failing a config that already works:
+#
+#   - The provider config's own model-NAME heuristics fire before the
+#     gate. On `bedrock` converse those are `gpt-oss` and Nova 2
+#     (`reasoning_effort` only — on those names `thinking` is never
+#     advertised at all, whatever you set) and `claude-3-7` /
+#     `claude-sonnet-4` / `claude-opus-4` / `deepseek.r1` (both knobs).
+#     A property of the model name, not of this file. Note that
+#     github_copilot's `"claude" in model` is NOT one of these: it is
+#     ANDed with the unreachable gate, so a Claude name alone never
+#     suffices there.
+#   - The bare, provider-stripped model name happens to be in LiteLLM's
+#     built-in map — `gemini-2.5-pro` is, so `vertex_ai/gemini-2.5-pro`
+#     carries the knob with no `model_info` and no config at all. That
+#     is a fact about LiteLLM's map at one version, so if you have SEEN
+#     the knob on the wire (see VERIFY below), record the observation
+#     rather than re-deriving it:
+#
+#       model_info:
+#         egg_wire_verified_knobs:
+#           reasoning_effort: "1.86.2"   # litellm version observed at
+#
+#     Like everything in `model_info` it goes on BOTH paired rows, and
+#     the guard honours it only while the image still pins that version —
+#     a bump moves the map, so the observation expires with it.
+#
+# Otherwise: use the provider's native request shape, or verify
 # empirically against `request_params` as below. The CI guard fails the
-# build on these rather than telling you to set a flag that does nothing.
+# build rather than telling you to set a flag that does nothing.
 #
 # LOOK FOR THE SHAPE, NOT THE PROVIDER NAME. Any list here is a snapshot
 # of one litellm version; the durable questions about a provider you are
@@ -156,8 +180,10 @@
 # whether it passes a `custom_llm_provider` when doing so:
 #
 #   - Fails closed, gate passes the provider — set `model_info`.
-#   - Fails closed, gate passes no (or a different) provider — nothing in
-#     this file helps; see the three named above.
+#   - Fails closed, gate passes no (or a different) provider —
+#     `model_info` can't help; see the three named above. Only a name the
+#     provider recognises without the gate, or one LiteLLM's map already
+#     knows, carries the knob.
 #   - Fails open — you don't need it: azure's o-series config calls
 #     `supports_reasoning` too, but assumes an unrecognised deployment
 #     name IS reasoning-capable, so the same call has the opposite

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -114,30 +114,60 @@
 #
 # THIS IS NOT AN OPENROUTER-ONLY TRAP, and `model_info` is not an
 # OpenRouter-only fix. Many other provider configs consult the same
-# `litellm.supports_reasoning` call — at litellm 1.86.2: `gemini` and
-# `vertex_ai` with exactly OpenRouter's shape (a bare gate, both knobs);
-# `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`, `perplexity`,
+# `litellm.supports_reasoning` call — at litellm 1.86.2: `gemini` with
+# exactly OpenRouter's shape (a bare gate, both knobs); `groq`, `xai`,
+# `deepinfra`, `cerebras`, `fireworks_ai`, `perplexity`,
 # `bedrock_mantle` gating `reasoning_effort`; `zai` and `minimax` gating
-# `thinking` and never advertising `reasoning_effort` at all;
-# `github_copilot` gating both but only for a "claude" model name; and
-# `anthropic` / `bedrock` falling back to the gate for any name their
-# heuristics don't already recognise. On all of them form 1 works,
-# because LiteLLM registers `model_info` into its model-cost map under a
-# key derived from `litellm_params` — `custom_llm_provider + "/" + model`
-# when that field is set, the raw `model` string otherwise — and the gate
-# reads that same map. Nothing on the path is OpenRouter-specific.
+# `thinking` and never advertising `reasoning_effort` at all; and
+# `anthropic` falling back to the gate for any name its own heuristics
+# don't already recognise. On those, form 1 works: LiteLLM registers
+# `model_info` into its model-cost map under a key derived from
+# `litellm_params` — `custom_llm_provider + "/" + model` when that field
+# is set, the raw `model` string otherwise — and the gate reads that same
+# map back. Nothing on the path is OpenRouter-specific.
+#
+# BUT "the provider gates the knob" is only half of what makes form 1
+# work. The other half is that the gate must look the model up WITH a
+# `custom_llm_provider`, spelled like the prefix you write — that is what
+# makes the lookup form the same key the router filed `model_info` under.
+# Three providers at 1.86.2 fail that half, and for them form 1 is a
+# placebo that looks exactly like the fix:
+#
+#   - `vertex_ai` and `github_copilot` call `supports_reasoning(model)`
+#     with no provider at all. LiteLLM's candidate-key builder then
+#     prefixes nothing, so the `vertex_ai/…` key your entry registered is
+#     never even a candidate.
+#   - `bedrock` (converse) does pass one, but its config reports
+#     `bedrock_converse` while the only prefix you can write is
+#     `bedrock/`. There is no third spelling that makes the two meet.
+#
+# On those routes the knob reaches the wire only if the provider config's
+# own model-name heuristics recognise the name (`claude-3-7`,
+# `claude-sonnet-4`, `claude-opus-4`, `deepseek.r1`, `gpt-oss`, Nova 2 on
+# bedrock; a "claude" name on github_copilot) — nothing in this file
+# changes that. Use the provider's native request shape, or verify
+# empirically against `request_params` as below. The CI guard fails the
+# build on these rather than telling you to set a flag that does nothing.
 #
 # LOOK FOR THE SHAPE, NOT THE PROVIDER NAME. Any list here is a snapshot
-# of one litellm version; the durable question is what that provider's
-# `get_supported_openai_params` does when the model is ABSENT from
-# LiteLLM's map. Fails closed (drops the knob) — set `model_info`. Fails
-# open — you don't need it: azure's o-series config calls
-# `supports_reasoning` too, but assumes an unrecognised deployment name
-# IS reasoning-capable, so the same call has the opposite failure mode.
-# Advertises the knob nowhere — nothing in this file helps: that is
-# `TogetherAIConfig`, which only subtracts from `OpenAIGPTConfig`'s base
-# list, and that base list carries no reasoning knob at all, so on a
-# `together_ai/*` row the parameter is popped silently whatever you set.
+# of one litellm version; the durable questions about a provider you are
+# about to configure are what its `get_supported_openai_params` does when
+# the model is ABSENT from LiteLLM's map, and — if it consults the map —
+# whether it passes a `custom_llm_provider` when doing so:
+#
+#   - Fails closed, gate passes the provider — set `model_info`.
+#   - Fails closed, gate passes no (or a different) provider — nothing in
+#     this file helps; see the three named above.
+#   - Fails open — you don't need it: azure's o-series config calls
+#     `supports_reasoning` too, but assumes an unrecognised deployment
+#     name IS reasoning-capable, so the same call has the opposite
+#     failure mode.
+#   - Advertises the knob nowhere — nothing in this file helps either:
+#     that is `TogetherAIConfig`, which only subtracts from
+#     `OpenAIGPTConfig`'s base list, and that base list carries no
+#     reasoning knob at all, so on a `together_ai/*` row the parameter is
+#     popped silently whatever you set.
+#
 # The answer is also per-knob, not per-provider (see `zai` above). The CI
 # guard tracks these cases separately, and pins the litellm version its
 # reading was done at — bump the image and the guard tells you to re-read

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -35,8 +35,8 @@
 # reach the LiteLLM Service can call it directly).
 #
 # Per-model tuning: anything LiteLLM accepts under `litellm_params`
-# (reasoning_effort, drop_params, extra_body, temperature, top_p,
-# seed, …) works here. See
+# (drop_params, extra_body, temperature, top_p, seed, …) works here.
+# See
 # https://docs.litellm.ai/docs/proxy/config_settings#model_list-params
 # for the full list. For routing parity with Anthropic Opus xhigh —
 # egg's current baseline — see the qwen3-max entry below; note that
@@ -44,6 +44,63 @@
 # tunable budget), so per-provider reasoning behavior will differ even
 # after tuning. Leave temperature / top_p / penalties at defaults for
 # cleaner cross-provider comparisons.
+#
+# EXCEPTION — `reasoning_effort` is NOT one of the knobs that "just
+# works" here, and gets its own rules below.
+#
+# ## reasoning_effort is silently dropped unless the model is flagged
+#
+# `litellm_params.reasoning_effort` reaches the wire only when LiteLLM
+# believes the model is reasoning-capable.
+# `OpenrouterConfig.get_supported_openai_params` advertises
+# `reasoning_effort` / `thinking` only if
+# `litellm.supports_reasoning(model)` is true, and that reads LiteLLM's
+# built-in model-cost map. A model ABSENT from that map answers False —
+# so the gate fails closed, and `drop_params: true` then discards the
+# parameter with no error and no log line.
+#
+# Absent is the NORMAL state for an OpenRouter slug: verified against
+# the pinned litellm 1.86.2, `qwen/qwen3-max` and
+# `moonshotai/kimi-k2-thinking` are both absent and both answer False
+# (`deepseek/deepseek-r1` is present and answers True). OpenRouter adds
+# models faster than LiteLLM's map tracks them, so a new slug is
+# unflagged by default. Setting `reasoning_effort` on one is a silent
+# no-op: the agent runs at the provider's default depth and nothing
+# anywhere says so.
+#
+# Two forms that DO reach the wire (both verified against 1.86.2):
+#
+#   1. Flag the model, then set the param. `model_info` is a sibling of
+#      `litellm_params`, not a key inside it:
+#
+#        - model_name: my-model
+#          litellm_params:
+#            model: openrouter/vendor/my-model
+#            api_key: os.environ/OPENROUTER_API_KEY
+#            drop_params: true
+#            reasoning_effort: high
+#          model_info:
+#            supports_reasoning: true    # REQUIRED, else the line above is a no-op
+#
+#      This is enforced in CI by tests/config/test_litellm_template.py
+#      for entries in this template.
+#
+#   2. Bypass the mapper with OpenRouter's native shape, which does not
+#      consult the model map at all (see the qwen3-max entry below):
+#
+#        extra_body:
+#          reasoning:
+#            effort: "high"
+#
+# Do NOT reach for `drop_params: false` to force it through. That flag
+# is what stops Anthropic-only fields LiteLLM cannot translate (e.g.
+# `thinking`) from 400ing tool-heavy turns; turning it off trades a
+# silent no-op for loud request failures.
+#
+# VERIFY, don't assume: the `cost_callback` logs `request_params` per
+# call, read from LiteLLM's post-mapping params — i.e. what the wire
+# actually carried (#3611). If `reasoning_effort` does not appear there
+# on real agent traffic, it was dropped, whatever this file says.
 #
 # Whatever you set here (or leave unset), the bundled `cost_callback`
 # records the sampling config each call actually ran under as
@@ -99,7 +156,13 @@ data:
               order: [Alibaba]
               allow_fallbacks: false
             # Closest knob to Opus xhigh — uncomment to opt into the
-            # deepest reasoning OpenRouter exposes for this model:
+            # deepest reasoning OpenRouter exposes for this model.
+            # Use THIS form, not `litellm_params.reasoning_effort`:
+            # OpenRouter's native `reasoning` block bypasses LiteLLM's
+            # param mapper, so it does not depend on the model being
+            # flagged reasoning-capable in LiteLLM's model map — which
+            # qwen3-max is not. See the "reasoning_effort is silently
+            # dropped" section at the top of this file.
             # reasoning:
             #   effort: "high"
       # Paired `[1m]` alias — absorbs Claude Code startup-probe

--- a/config/litellm-models.template.yaml
+++ b/config/litellm-models.template.yaml
@@ -50,8 +50,10 @@
 #
 # ## reasoning_effort is silently dropped unless the model is flagged
 #
-# On `openrouter/*` routes, `litellm_params.reasoning_effort` reaches
-# the wire only when LiteLLM believes the model is reasoning-capable.
+# On many providers — `openrouter/*` among them, but far from only it
+# (see the shape to look for below) — `litellm_params.reasoning_effort`
+# reaches the wire only when LiteLLM believes the model is
+# reasoning-capable. Taking OpenRouter as the worked example:
 # `OpenrouterConfig.get_supported_openai_params` advertises
 # `reasoning_effort` / `thinking` — both under the same condition — only
 # if `litellm.supports_reasoning(model)` is true, and that reads
@@ -111,24 +113,42 @@
 # for loud request failures.
 #
 # THIS IS NOT AN OPENROUTER-ONLY TRAP, and `model_info` is not an
-# OpenRouter-only fix. Verified at litellm 1.86.2, nine other provider
-# configs gate a reasoning knob on the same `litellm.supports_reasoning`
-# call, fail-closed in the same way: `groq`, `xai`, `deepinfra`,
-# `cerebras`, `fireworks_ai`, `perplexity` and `bedrock_mantle` gate
-# `reasoning_effort`; `zai` and `minimax` gate `thinking` (and never
-# advertise `reasoning_effort` at all). On all of them form 1 works,
-# because LiteLLM registers `model_info` into its model-cost map under
-# the raw `litellm_params.model` string whatever the provider.
+# OpenRouter-only fix. Many other provider configs consult the same
+# `litellm.supports_reasoning` call — at litellm 1.86.2: `gemini` and
+# `vertex_ai` with exactly OpenRouter's shape (a bare gate, both knobs);
+# `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`, `perplexity`,
+# `bedrock_mantle` gating `reasoning_effort`; `zai` and `minimax` gating
+# `thinking` and never advertising `reasoning_effort` at all;
+# `github_copilot` gating both but only for a "claude" model name; and
+# `anthropic` / `bedrock` falling back to the gate for any name their
+# heuristics don't already recognise. On all of them form 1 works,
+# because LiteLLM registers `model_info` into its model-cost map under a
+# key derived from `litellm_params` — `custom_llm_provider + "/" + model`
+# when that field is set, the raw `model` string otherwise — and the gate
+# reads that same map. Nothing on the path is OpenRouter-specific.
 #
-# Where `model_info` really is a placebo is a provider whose chat config
-# never consults `supports_reasoning` — e.g. `TogetherAIConfig`, which
-# only subtracts from `OpenAIGPTConfig`'s base list, and that base list
-# carries no reasoning knob at all. On a `together_ai/*` row the
-# parameter is popped silently whatever you set. So: check the
-# provider's `get_supported_openai_params` before setting the knob, and
-# note that the answer is per-knob, not per-provider. The CI guard
-# tracks the two cases separately (see the provider tables in
-# tests/config/test_litellm_template.py).
+# LOOK FOR THE SHAPE, NOT THE PROVIDER NAME. Any list here is a snapshot
+# of one litellm version; the durable question is what that provider's
+# `get_supported_openai_params` does when the model is ABSENT from
+# LiteLLM's map. Fails closed (drops the knob) — set `model_info`. Fails
+# open — you don't need it: azure's o-series config calls
+# `supports_reasoning` too, but assumes an unrecognised deployment name
+# IS reasoning-capable, so the same call has the opposite failure mode.
+# Advertises the knob nowhere — nothing in this file helps: that is
+# `TogetherAIConfig`, which only subtracts from `OpenAIGPTConfig`'s base
+# list, and that base list carries no reasoning knob at all, so on a
+# `together_ai/*` row the parameter is popped silently whatever you set.
+# The answer is also per-knob, not per-provider (see `zai` above). The CI
+# guard tracks these cases separately, and pins the litellm version its
+# reading was done at — bump the image and the guard tells you to re-read
+# (see the provider tables in tests/config/test_litellm_template.py).
+#
+# One shape to avoid whichever form you use: do not spell the provider
+# twice. A prefixed `model: openrouter/vendor/x` PLUS
+# `custom_llm_provider: openrouter` registers `model_info` under
+# `openrouter/openrouter/vendor/x` (LiteLLM prepends unconditionally)
+# while the gate looks up `openrouter/vendor/x` — flag set, flag never
+# read, knob dropped, config looking correct. Pick one spelling.
 #
 # VERIFY, don't assume: the `cost_callback` logs `request_params` per
 # call, read from LiteLLM's post-mapping params — i.e. what the wire

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -655,10 +655,11 @@ kubectl logs -n egg-system deploy/litellm \
 ```
 
 > **Trap: `reasoning_effort` in `litellm_params` is a silent no-op unless the
-> model is flagged.** This bites on `openrouter/*` and on nine other providers
-> (enumerated below). LiteLLM sends it only if it
-> believes the model is reasoning-capable:
-> `OpenrouterConfig.get_supported_openai_params` advertises
+> model is flagged.** This bites on `openrouter/*` and on a range of other
+> providers — the shape to look for is below, and it is not a short list.
+> LiteLLM sends the knob only if it
+> believes the model is reasoning-capable; taking OpenRouter as the worked
+> example, `OpenrouterConfig.get_supported_openai_params` advertises
 > `reasoning_effort`/`thinking` — both under the same condition — only when
 > `litellm.supports_reasoning(model)` is true, and that reads LiteLLM's
 > built-in model-cost map. **A model absent from that map answers `False`**,
@@ -705,23 +706,48 @@ kubectl logs -n egg-system deploy/litellm \
 > instead. You would trade a silent no-op for loud request failures.
 >
 > **This is not an OpenRouter-only trap, and form 1 is not an OpenRouter-only
-> fix.** Verified at litellm 1.86.2, nine other provider configs gate a
-> reasoning knob on the same `litellm.supports_reasoning` call and fail closed
-> identically: `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`,
-> `perplexity` and `bedrock_mantle` gate `reasoning_effort`; `zai` and
-> `minimax` gate `thinking`, and never advertise `reasoning_effort` at all. On
-> every one of them `model_info` is the working fix, because
-> `Router._create_deployment` registers it into LiteLLM's model-cost map under
-> the raw `litellm_params.model` string — nothing on that path is
-> OpenRouter-specific.
+> fix.** Many other provider configs consult the same
+> `litellm.supports_reasoning` call. At litellm 1.86.2: `gemini` and
+> `vertex_ai` with exactly OpenRouter's shape — a bare gate on both knobs;
+> `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`, `perplexity` and
+> `bedrock_mantle` gating `reasoning_effort`; `zai` and `minimax` gating
+> `thinking` and never advertising `reasoning_effort` at all;
+> `github_copilot` gating both but only for a `claude`-named model; and
+> `anthropic` / `bedrock` (converse) falling back to the gate for any name
+> their own heuristics don't recognise. On all of them `model_info` is the
+> working fix, because `Router._create_deployment` registers it into LiteLLM's
+> model-cost map under a key built from `litellm_params`
+> (`custom_llm_provider + "/" + model` when that field is set, the raw `model`
+> string otherwise) and the gate reads back that same map — nothing on the path
+> is OpenRouter-specific.
 >
-> Where `model_info` genuinely is a placebo is a provider whose chat config
-> never consults `supports_reasoning` at all: `TogetherAIConfig` only subtracts
-> from `OpenAIGPTConfig`'s base list, and that base list carries no reasoning
-> knob under any condition, so on a `together_ai/*` route the parameter is
-> popped silently whatever you set. Check that provider's
-> `get_supported_openai_params` before setting the knob — and note the answer
-> is per *knob*, not per provider.
+> **Look for the shape, not the provider name.** Any such list is a snapshot of
+> one litellm version, and a hard count of providers rots on the next bump. The
+> durable question about a provider you are about to configure is what its
+> `get_supported_openai_params` does when the model is *absent* from LiteLLM's
+> map:
+>
+> - **Fails closed** (drops the knob) → set `model_info`. Every provider named
+>   above is this case.
+> - **Fails open** → you don't need it. Azure's o-series config calls
+>   `supports_reasoning` too but *assumes* an unrecognised deployment name is
+>   reasoning-capable — the same call with the opposite failure mode, which is
+>   why the call alone isn't the test.
+> - **Never advertises the knob** → nothing in the config helps.
+>   `TogetherAIConfig` only subtracts from `OpenAIGPTConfig`'s base list, and
+>   that base list carries no reasoning knob under any condition, so on a
+>   `together_ai/*` route the parameter is popped silently whatever you set.
+>
+> Note the answer is per *knob*, not per provider (`zai` above), and per
+> litellm version: `tests/config/test_litellm_template.py` pins the version its
+> provider tables were read at and fails the build when the image moves past
+> it, so a bump forces the re-read instead of quietly invalidating the tables.
+>
+> Whichever form you use, don't spell the provider twice: a prefixed
+> `model: openrouter/vendor/x` *plus* `custom_llm_provider: openrouter`
+> registers `model_info` under `openrouter/openrouter/vendor/x` (LiteLLM
+> prepends unconditionally) while the gate looks up `openrouter/vendor/x` — the
+> flag is set, never read, and the knob is dropped by a config that looks right.
 >
 > `tests/config/test_litellm_template.py` guards both cases for the committed
 > template. Operator overlays are not in CI, so verify yours against

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -707,33 +707,55 @@ kubectl logs -n egg-system deploy/litellm \
 >
 > **This is not an OpenRouter-only trap, and form 1 is not an OpenRouter-only
 > fix.** Many other provider configs consult the same
-> `litellm.supports_reasoning` call. At litellm 1.86.2: `gemini` and
-> `vertex_ai` with exactly OpenRouter's shape — a bare gate on both knobs;
+> `litellm.supports_reasoning` call. At litellm 1.86.2: `gemini` with exactly
+> OpenRouter's shape — a bare gate on both knobs;
 > `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`, `perplexity` and
 > `bedrock_mantle` gating `reasoning_effort`; `zai` and `minimax` gating
-> `thinking` and never advertising `reasoning_effort` at all;
-> `github_copilot` gating both but only for a `claude`-named model; and
-> `anthropic` / `bedrock` (converse) falling back to the gate for any name
-> their own heuristics don't recognise. On all of them `model_info` is the
-> working fix, because `Router._create_deployment` registers it into LiteLLM's
+> `thinking` and never advertising `reasoning_effort` at all; and
+> `anthropic` falling back to the gate for any name its own heuristics don't
+> recognise. On those, `model_info` is the working fix, because
+> `Router._create_deployment` registers it into LiteLLM's
 > model-cost map under a key built from `litellm_params`
 > (`custom_llm_provider + "/" + model` when that field is set, the raw `model`
 > string otherwise) and the gate reads back that same map — nothing on the path
 > is OpenRouter-specific.
 >
+> **"Gates the knob" is only half of what makes form 1 work.** The other half is
+> that the gate must look the model up *with* a `custom_llm_provider` spelled
+> like the prefix you write — that is what makes its lookup build the same key
+> the router filed `model_info` under. Three providers at 1.86.2 fail that half,
+> and there form 1 is a placebo indistinguishable from the fix:
+>
+> - `vertex_ai` and `github_copilot` call `supports_reasoning(model)` with no
+>   provider, so LiteLLM's candidate-key builder prefixes nothing
+>   (`litellm/utils.py:5554-5565`) and the `vertex_ai/…` key your entry
+>   registered is never a candidate.
+> - `bedrock` (converse) does pass one, but its config reports
+>   `bedrock_converse` while the only prefix you can write is `bedrock/` —
+>   and `bedrock_converse` is not a provider prefix, so there is no third
+>   spelling that makes the write key and the read key meet.
+>
+> On those routes only the provider config's own name heuristics can carry the
+> knob (`claude-3-7`, `claude-sonnet-4`, `claude-opus-4`, `deepseek.r1`,
+> `gpt-oss`, Nova 2 on bedrock; a `claude` name on github_copilot) — a property
+> of the model name, not of your config. Use the provider's native request
+> shape, or verify empirically against `request_params` below. The CI guard
+> fails the build on these rather than sending you to a flag that does nothing.
+>
 > **Look for the shape, not the provider name.** Any such list is a snapshot of
 > one litellm version, and a hard count of providers rots on the next bump. The
-> durable question about a provider you are about to configure is what its
+> durable questions about a provider you are about to configure are what its
 > `get_supported_openai_params` does when the model is *absent* from LiteLLM's
-> map:
+> map, and — if it consults the map — whether it passes a `custom_llm_provider`:
 >
-> - **Fails closed** (drops the knob) → set `model_info`. Every provider named
->   above is this case.
+> - **Fails closed, gate passes the provider** → set `model_info`.
+> - **Fails closed, gate passes no (or a different) provider** → nothing in the
+>   config helps; the three named above are this case.
 > - **Fails open** → you don't need it. Azure's o-series config calls
 >   `supports_reasoning` too but *assumes* an unrecognised deployment name is
 >   reasoning-capable — the same call with the opposite failure mode, which is
 >   why the call alone isn't the test.
-> - **Never advertises the knob** → nothing in the config helps.
+> - **Never advertises the knob** → nothing in the config helps either.
 >   `TogetherAIConfig` only subtracts from `OpenAIGPTConfig`'s base list, and
 >   that base list carries no reasoning knob under any condition, so on a
 >   `together_ai/*` route the parameter is popped silently whatever you set.

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -611,8 +611,9 @@ data:
 > **Which decoding config did this run under?** Every `cost_callback` line
 > also carries `request_params` — the sampling configuration that actually
 > went upstream on that call (`temperature`, `top_p`, `top_k`, the penalty
-> family, `seed`, `max_tokens`, `reasoning_effort`, and the OpenRouter
-> provider pin under `extra_body`). This exists because repetition and
+> family, `seed`, `max_tokens`, the reasoning family — `reasoning_effort`,
+> `reasoning`, `thinking` — and the OpenRouter provider pin under
+> `extra_body`). This exists because repetition and
 > degeneration are decoding-sensitive failure modes: without it, "was that
 > livelock inherent to the model or an unlucky sampling config?" is
 > unanswerable once the pod is gone (issue #3599; it blocked the #3598
@@ -631,47 +632,6 @@ data:
 >
 > Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
 > allowlist: the cost stream is not a transcript sink.
-
-> **Trap: `reasoning_effort` in `litellm_params` is usually a silent no-op.**
-> LiteLLM sends it only if it believes the model is reasoning-capable:
-> `OpenrouterConfig.get_supported_openai_params` advertises
-> `reasoning_effort`/`thinking` only when `litellm.supports_reasoning(model)`
-> is true, and that reads LiteLLM's built-in model-cost map. **A model absent
-> from that map answers `False`**, so the gate fails closed and
-> `drop_params: true` discards the parameter with no error and no log line.
->
-> Absent is the *normal* state for an OpenRouter slug — verified against the
-> pinned litellm 1.86.2, `qwen/qwen3-max` and `moonshotai/kimi-k2-thinking`
-> are both absent and answer `False`, while `deepseek/deepseek-r1` is present
-> and answers `True`. OpenRouter adds models faster than LiteLLM's map tracks
-> them, so a new slug is unflagged by default and the agent quietly runs at
-> the provider's default reasoning depth.
->
-> Two forms that do reach the wire:
->
-> ```yaml
-> # 1. Flag the model. `model_info` is a SIBLING of litellm_params.
-> - model_name: my-model
->   litellm_params:
->     model: openrouter/vendor/my-model
->     reasoning_effort: high
->   model_info:
->     supports_reasoning: true    # without this, the line above does nothing
->
-> # 2. Or bypass the mapper with OpenRouter's native block, which never
-> #    consults the model map:
->   litellm_params:
->     extra_body:
->       reasoning:
->         effort: "high"
-> ```
->
-> Do **not** reach for `drop_params: false` to force it through — that flag is
-> what stops Anthropic-only fields LiteLLM cannot translate (e.g. `thinking`)
-> from 400ing tool-heavy turns. You would trade a silent no-op for loud
-> request failures. `tests/config/test_litellm_template.py` guards form 1 for
-> the committed template; operator overlays are not in CI, so verify yours
-> against `request_params` in the pod stream.
 
 The `request_params` field on a stock (nothing pinned) OpenRouter route:
 
@@ -693,6 +653,70 @@ kubectl logs -n egg-system deploy/litellm \
             | {model: .context.model, params: .context.request_params}' \
   | sort -u
 ```
+
+> **Trap: on `openrouter/*`, `reasoning_effort` in `litellm_params` is a
+> silent no-op unless the model is flagged.** LiteLLM sends it only if it
+> believes the model is reasoning-capable:
+> `OpenrouterConfig.get_supported_openai_params` advertises
+> `reasoning_effort`/`thinking` — both under the same condition — only when
+> `litellm.supports_reasoning(model)` is true, and that reads LiteLLM's
+> built-in model-cost map. **A model absent from that map answers `False`**,
+> so the gate fails closed and `drop_params: true` discards the parameter with
+> no error and no log line.
+>
+> Absent is the *normal* state for an OpenRouter slug — verified against the
+> pinned litellm 1.86.2, `qwen/qwen3-max` and `moonshotai/kimi-k2-thinking`
+> are both absent and answer `False`, while `deepseek/deepseek-r1` is present
+> and answers `True`. OpenRouter adds models faster than LiteLLM's map tracks
+> them, so a new slug is unflagged by default and the agent quietly runs at
+> the provider's default reasoning depth.
+>
+> Two forms that do reach the wire. Form 1 — flag the model; `model_info` is a
+> **sibling** of `litellm_params`, not a key inside it (mirror both blocks onto
+> the paired `[1m]` row, omitted here for brevity):
+>
+> ```yaml
+> - model_name: my-model
+>   litellm_params:
+>     model: openrouter/vendor/my-model
+>     reasoning_effort: high
+>   model_info:
+>     supports_reasoning: true    # without this, the line above does nothing
+> ```
+>
+> Form 2 — bypass the mapper with OpenRouter's native block, which never
+> consults the model map:
+>
+> ```yaml
+> - model_name: my-model
+>   litellm_params:
+>     model: openrouter/vendor/my-model
+>     extra_body:
+>       reasoning:
+>         effort: "high"
+> ```
+>
+> Do **not** reach for `drop_params: false` to force it through — that flag is
+> what stops Anthropic-only fields LiteLLM cannot translate (e.g. `thinking`)
+> from 400ing tool-heavy turns, and turning it off does not pass the parameter
+> through anyway: `_check_valid_arg` raises `UnsupportedParamsError` (HTTP 500)
+> instead. You would trade a silent no-op for loud request failures.
+>
+> **Off OpenRouter, `model_info` is not the fix** — `supports_reasoning` is
+> read only by `OpenrouterConfig`. Other providers answer from a static list
+> (`TogetherAIConfig` just subtracts from `OpenAIGPTConfig`'s base list, which
+> carries no `reasoning_effort` at all), so the flag is a placebo there and the
+> parameter is still popped silently. Check that provider's
+> `get_supported_openai_params` before setting the knob; most
+> OpenAI-compatible ones never advertise it.
+>
+> `tests/config/test_litellm_template.py` guards both cases for the committed
+> template. Operator overlays are not in CI, so verify yours against
+> `request_params` above — **and grep for the right key**: form 1 logs
+> `reasoning_effort`, form 2 logs `reasoning` (`cost_callback` hoists it out of
+> `extra_body` to the flat level, so a working form-2 route shows
+> `"reasoning": {"effort": "high"}` and *never* shows `reasoning_effort`).
+> Neither key on real agent traffic means it was dropped.
 
 > **Why the paired `<name>[1m]` row?** Claude Code registers the
 > custom model with a `[1m]` context-window-opt-in suffix

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -632,6 +632,47 @@ data:
 > Prompt-bearing fields (`messages`, `tools`, `tool_choice`) are excluded by
 > allowlist: the cost stream is not a transcript sink.
 
+> **Trap: `reasoning_effort` in `litellm_params` is usually a silent no-op.**
+> LiteLLM sends it only if it believes the model is reasoning-capable:
+> `OpenrouterConfig.get_supported_openai_params` advertises
+> `reasoning_effort`/`thinking` only when `litellm.supports_reasoning(model)`
+> is true, and that reads LiteLLM's built-in model-cost map. **A model absent
+> from that map answers `False`**, so the gate fails closed and
+> `drop_params: true` discards the parameter with no error and no log line.
+>
+> Absent is the *normal* state for an OpenRouter slug — verified against the
+> pinned litellm 1.86.2, `qwen/qwen3-max` and `moonshotai/kimi-k2-thinking`
+> are both absent and answer `False`, while `deepseek/deepseek-r1` is present
+> and answers `True`. OpenRouter adds models faster than LiteLLM's map tracks
+> them, so a new slug is unflagged by default and the agent quietly runs at
+> the provider's default reasoning depth.
+>
+> Two forms that do reach the wire:
+>
+> ```yaml
+> # 1. Flag the model. `model_info` is a SIBLING of litellm_params.
+> - model_name: my-model
+>   litellm_params:
+>     model: openrouter/vendor/my-model
+>     reasoning_effort: high
+>   model_info:
+>     supports_reasoning: true    # without this, the line above does nothing
+>
+> # 2. Or bypass the mapper with OpenRouter's native block, which never
+> #    consults the model map:
+>   litellm_params:
+>     extra_body:
+>       reasoning:
+>         effort: "high"
+> ```
+>
+> Do **not** reach for `drop_params: false` to force it through — that flag is
+> what stops Anthropic-only fields LiteLLM cannot translate (e.g. `thinking`)
+> from 400ing tool-heavy turns. You would trade a silent no-op for loud
+> request failures. `tests/config/test_litellm_template.py` guards form 1 for
+> the committed template; operator overlays are not in CI, so verify yours
+> against `request_params` in the pod stream.
+
 The `request_params` field on a stock (nothing pinned) OpenRouter route:
 
 ```json

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -751,12 +751,40 @@ kubectl logs -n egg-system deploy/litellm \
 >   and `bedrock_converse` is not a provider prefix, so there is no third
 >   spelling that makes the write key and the read key meet.
 >
-> On those routes only the provider config's own name heuristics can carry the
-> knob (`claude-3-7`, `claude-sonnet-4`, `claude-opus-4`, `deepseek.r1`,
-> `gpt-oss`, Nova 2 on bedrock; a `claude` name on github_copilot) — a property
-> of the model name, not of your config. Use the provider's native request
-> shape, or verify empirically against `request_params` below. The CI guard
-> fails the build on these rather than sending you to a flag that does nothing.
+> **"`model_info` can't rescue it" is not "it can't work."** Two other things
+> still carry the knob on those routes, and the CI guard accepts both rather
+> than failing a config that already works:
+>
+> - The provider config's own model-**name** heuristics, which fire before the
+>   gate is consulted. On `bedrock` converse: `gpt-oss` and Nova 2
+>   (`reasoning_effort` only — the `if`/`elif` chain returns before the branch
+>   that appends `thinking`, so on those names `thinking` is never advertised
+>   whatever you set), and `claude-3-7` / `claude-sonnet-4` / `claude-opus-4` /
+>   `deepseek.r1` (both knobs). A property of the model name, not of your
+>   config. `github_copilot`'s `"claude" in model` is *not* one of these — it is
+>   **AND**ed with the unreachable gate, so a Claude name alone never suffices
+>   (the gate additionally needs the bare `claude-sonnet-4`, not
+>   `github_copilot/claude-sonnet-4`, to be in LiteLLM's map).
+> - The bare, provider-stripped model name happening to be a top-level key in
+>   LiteLLM's built-in map. `gemini-2.5-pro` is one, so
+>   `model: vertex_ai/gemini-2.5-pro` puts the knob on the wire with no
+>   `model_info` and no config at all. That is a fact about LiteLLM's map at one
+>   version rather than about your entry, so if you have *seen* the knob on the
+>   `request_params` line, record the observation instead of re-deriving it:
+>
+>   ```yaml
+>   model_info:
+>     egg_wire_verified_knobs:
+>       reasoning_effort: "1.86.2"   # litellm version it was observed at
+>   ```
+>
+>   Like everything in `model_info` it belongs on both paired rows, and the
+>   guard honours it only while the image still pins that version — a bump moves
+>   the map, so the observation expires with it.
+>
+> Otherwise: use the provider's native request shape, or verify empirically
+> against `request_params` below. The CI guard fails the build rather than
+> sending you to a flag that does nothing.
 >
 > **Look for the shape, not the provider name.** Any such list is a snapshot of
 > one litellm version, and a hard count of providers rots on the next bump. The
@@ -765,8 +793,10 @@ kubectl logs -n egg-system deploy/litellm \
 > map, and — if it consults the map — whether it passes a `custom_llm_provider`:
 >
 > - **Fails closed, gate passes the provider** → set `model_info`.
-> - **Fails closed, gate passes no (or a different) provider** → nothing in the
->   config helps; the three named above are this case.
+> - **Fails closed, gate passes no (or a different) provider** → `model_info`
+>   can't help; the three named above are this case. Only a name the provider
+>   recognises without the gate, or one LiteLLM's map already knows, carries the
+>   knob.
 > - **Fails open** → you don't need it. Azure's o-series config calls
 >   `supports_reasoning` too but *assumes* an unrecognised deployment name is
 >   reasoning-capable — the same call with the opposite failure mode, which is

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -715,6 +715,28 @@ kubectl logs -n egg-system deploy/litellm \
 >         effort: "high"
 > ```
 >
+> **Prefer form 2 on OpenRouter routes.** Form 1 gets the parameter past
+> LiteLLM, which is a different claim from the provider honouring it:
+> `supports_reasoning: true` asserts *"LiteLLM, stop dropping this"*, and what
+> it then puts on the wire is the OpenAI-style `reasoning_effort`. Not every
+> OpenRouter endpoint accepts that key. OpenRouter is the authority, and it
+> answers **per endpoint**, not per model:
+>
+> ```bash
+> curl -s https://openrouter.ai/api/v1/models/<vendor>/<slug>/endpoints \
+>   | jq '.data.endpoints[] | {provider: .provider_name, params: .supported_parameters}'
+> ```
+>
+> Verified 2026-07-25: all 33 of `z-ai/glm-5.2`'s endpoints list **both**
+> `reasoning` and `reasoning_effort`, but `poolside/laguna-s-2.1` (sole
+> endpoint, Poolside) lists `reasoning` and `include_reasoning` and **not**
+> `reasoning_effort`. Since every entry here carries a `provider.order` pin
+> with `allow_fallbacks: false`, what matters is the endpoint you pinned — not
+> the model-level union that `/api/v1/models` reports, which is a union across
+> endpoints and so over-reports for a pinned route. Form 2 sends `reasoning`,
+> the key OpenRouter itself documents, which in this sample is supported
+> everywhere `reasoning_effort` is *plus* where it is absent.
+>
 > Do **not** reach for `drop_params: false` to force it through — that flag is
 > what stops Anthropic-only fields LiteLLM cannot translate (e.g. `thinking`)
 > from 400ing tool-heavy turns, and turning it off does not pass the parameter

--- a/docs/guides/per-agent-models.md
+++ b/docs/guides/per-agent-models.md
@@ -654,8 +654,9 @@ kubectl logs -n egg-system deploy/litellm \
   | sort -u
 ```
 
-> **Trap: on `openrouter/*`, `reasoning_effort` in `litellm_params` is a
-> silent no-op unless the model is flagged.** LiteLLM sends it only if it
+> **Trap: `reasoning_effort` in `litellm_params` is a silent no-op unless the
+> model is flagged.** This bites on `openrouter/*` and on nine other providers
+> (enumerated below). LiteLLM sends it only if it
 > believes the model is reasoning-capable:
 > `OpenrouterConfig.get_supported_openai_params` advertises
 > `reasoning_effort`/`thinking` — both under the same condition — only when
@@ -685,7 +686,8 @@ kubectl logs -n egg-system deploy/litellm \
 > ```
 >
 > Form 2 — bypass the mapper with OpenRouter's native block, which never
-> consults the model map:
+> consults the model map (this one lives *inside* `litellm_params`, and like
+> everything else there it must be mirrored onto the paired `[1m]` row):
 >
 > ```yaml
 > - model_name: my-model
@@ -702,13 +704,24 @@ kubectl logs -n egg-system deploy/litellm \
 > through anyway: `_check_valid_arg` raises `UnsupportedParamsError` (HTTP 500)
 > instead. You would trade a silent no-op for loud request failures.
 >
-> **Off OpenRouter, `model_info` is not the fix** — `supports_reasoning` is
-> read only by `OpenrouterConfig`. Other providers answer from a static list
-> (`TogetherAIConfig` just subtracts from `OpenAIGPTConfig`'s base list, which
-> carries no `reasoning_effort` at all), so the flag is a placebo there and the
-> parameter is still popped silently. Check that provider's
-> `get_supported_openai_params` before setting the knob; most
-> OpenAI-compatible ones never advertise it.
+> **This is not an OpenRouter-only trap, and form 1 is not an OpenRouter-only
+> fix.** Verified at litellm 1.86.2, nine other provider configs gate a
+> reasoning knob on the same `litellm.supports_reasoning` call and fail closed
+> identically: `groq`, `xai`, `deepinfra`, `cerebras`, `fireworks_ai`,
+> `perplexity` and `bedrock_mantle` gate `reasoning_effort`; `zai` and
+> `minimax` gate `thinking`, and never advertise `reasoning_effort` at all. On
+> every one of them `model_info` is the working fix, because
+> `Router._create_deployment` registers it into LiteLLM's model-cost map under
+> the raw `litellm_params.model` string — nothing on that path is
+> OpenRouter-specific.
+>
+> Where `model_info` genuinely is a placebo is a provider whose chat config
+> never consults `supports_reasoning` at all: `TogetherAIConfig` only subtracts
+> from `OpenAIGPTConfig`'s base list, and that base list carries no reasoning
+> knob under any condition, so on a `together_ai/*` route the parameter is
+> popped silently whatever you set. Check that provider's
+> `get_supported_openai_params` before setting the knob — and note the answer
+> is per *knob*, not per provider.
 >
 > `tests/config/test_litellm_template.py` guards both cases for the committed
 > template. Operator overlays are not in CI, so verify yours against

--- a/k8s/base/litellm-configmap.yaml
+++ b/k8s/base/litellm-configmap.yaml
@@ -27,13 +27,19 @@ data:
     #
     # Operators add backends per LiteLLM's documented format. Each
     # non-Claude entry SHOULD ship paired (bare, ``[1m]``-suffixed)
-    # ``model_name`` rows that point at the same ``litellm_params``
+    # ``model_name`` rows carrying the same ``litellm_params`` AND the
+    # same ``model_info``
     # (#2832): Claude Code strips the ``[1m]`` suffix from the model
     # field before send, but a handful of startup probes leak the
     # suffix onto the wire — without the alias LiteLLM 400s those
     # probes with ``Invalid model name``. The two-row shape eats that
-    # noise without needing a gateway-side body rewrite. E.g. for the
-    # OpenRouter pilot backend (cq-6):
+    # noise without needing a gateway-side body rewrite. Both blocks
+    # must match: ``model_info.supports_reasoning`` decides whether a
+    # ``reasoning_effort`` / ``thinking`` knob reaches the wire at all,
+    # so divergence there means probes and real requests run at
+    # different reasoning depths. Both parities are CI-enforced for the
+    # committed template by ``tests/config/test_litellm_template.py``.
+    # E.g. for the OpenRouter pilot backend (cq-6):
     #
     #   model_list:
     #     - model_name: qwen3-max

--- a/k8s/base/litellm-configmap.yaml
+++ b/k8s/base/litellm-configmap.yaml
@@ -28,17 +28,17 @@ data:
     # Operators add backends per LiteLLM's documented format. Each
     # non-Claude entry SHOULD ship paired (bare, ``[1m]``-suffixed)
     # ``model_name`` rows carrying the same ``litellm_params`` AND the
-    # same ``model_info``
-    # (#2832): Claude Code strips the ``[1m]`` suffix from the model
-    # field before send, but a handful of startup probes leak the
-    # suffix onto the wire — without the alias LiteLLM 400s those
-    # probes with ``Invalid model name``. The two-row shape eats that
-    # noise without needing a gateway-side body rewrite. Both blocks
-    # must match: ``model_info.supports_reasoning`` decides whether a
-    # ``reasoning_effort`` / ``thinking`` knob reaches the wire at all,
-    # so divergence there means probes and real requests run at
-    # different reasoning depths. Both parities are CI-enforced for the
-    # committed template by ``tests/config/test_litellm_template.py``.
+    # same ``model_info`` (#2832): Claude Code strips the ``[1m]``
+    # suffix from the model field before send, but a handful of startup
+    # probes leak the suffix onto the wire — without the alias LiteLLM
+    # 400s those probes with ``Invalid model name``. The two-row shape
+    # eats that noise without needing a gateway-side body rewrite. Both
+    # blocks must match: ``model_info.supports_reasoning`` decides
+    # whether a ``reasoning_effort`` / ``thinking`` knob reaches the
+    # wire at all, so divergence there means probes and real requests
+    # run at different reasoning depths. Both parities are CI-enforced
+    # for the committed template by
+    # ``tests/config/test_litellm_template.py``.
     # E.g. for the OpenRouter pilot backend (cq-6):
     #
     #   model_list:

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -13,12 +13,11 @@ This test file enforces five guarantees: every bare row has its
 share equal ``litellm_params`` and equal ``model_info`` (both compared
 as parsed YAML) — so probes and real requests can never be quietly
 routed through different configs — and no entry sets a reasoning knob
-(``reasoning_effort`` / ``thinking``) in a shape LiteLLM silently
-drops. It catches a
-forgetting operator who adds a new backend without its paired alias or
-lets the two rows' params drift. Commented-out example entries in the
-template are YAML comments, not parsed entries, so they're naturally
-excluded.
+(``reasoning_effort`` / ``thinking``) in a shape LiteLLM silently drops.
+It catches a forgetting operator who adds a new backend without its
+paired alias or lets the two rows' params drift. Commented-out example
+entries in the template are YAML comments, not parsed entries, so
+they're naturally excluded.
 """
 
 from pathlib import Path
@@ -30,26 +29,58 @@ LITELLM_TEMPLATE = REPO_ROOT / "config" / "litellm-models.template.yaml"
 
 _ALIAS_SUFFIX = "[1m]"
 
-_OPENROUTER_PREFIX = "openrouter/"
-
-# Both knobs are appended under the same ``litellm.supports_reasoning``
-# condition in ``OpenrouterConfig.get_supported_openai_params``, so both are
-# dropped in the same silence for an unflagged model — guarding only
-# ``reasoning_effort`` would leave the identical trap open one key over.
+# The reasoning knobs LiteLLM can silently drop. Both are appended under the
+# same ``litellm.supports_reasoning`` condition in
+# ``OpenrouterConfig.get_supported_openai_params``, so both are dropped in the
+# same silence for an unflagged model — guarding only ``reasoning_effort``
+# would leave the identical trap open one key over.
 _REASONING_KNOBS = ("reasoning_effort", "thinking")
 
-# Non-OpenRouter provider prefixes whose LiteLLM chat config has been verified
-# to advertise ``reasoning_effort`` at all.
+# Provider prefix -> the reasoning knobs that provider's LiteLLM chat config
+# advertises ONLY when ``litellm.supports_reasoning(model, provider)`` is true.
 #
-# EMPTY BY DESIGN. ``model_info.supports_reasoning`` is an OpenRouter-specific
-# mechanism: only ``OpenrouterConfig`` consults ``litellm.supports_reasoning``.
-# Other providers answer from a static list — e.g. ``TogetherAIConfig`` only
-# subtracts from ``OpenAIGPTConfig``'s base list, which contains no
-# ``reasoning_effort`` under any condition — so setting ``model_info`` there
-# changes nothing and the parameter is still popped silently. Add a prefix
-# here only after reading that provider's ``get_supported_openai_params``
-# against the pinned litellm version, and say which version you checked.
-_REASONING_EFFORT_NATIVE_PROVIDERS: tuple[str, ...] = ()
+# For these prefix/knob combinations, and only these, ``model_info:
+# {supports_reasoning: true}`` on the entry is the fix: ``Router._create_deployment``
+# registers the entry's ``model_info`` into ``litellm.model_cost`` keyed by the
+# raw ``litellm_params.model`` string (``litellm/router.py:7911-7923``), which is
+# exactly what ``supports_reasoning`` reads back. Nothing in that path is
+# OpenRouter-specific.
+#
+# Verified by reading each ``get_supported_openai_params`` at the pinned litellm
+# **v1.86.2** (``config/litellm/Dockerfile``). This set moves on a version bump —
+# re-read the configs and update the version noted here when you bump.
+#
+# Note the knob column: ``zai`` and ``minimax`` gate ``thinking`` only and never
+# advertise ``reasoning_effort`` at all, so a per-provider tuple would be wrong
+# for them. That is why this maps to knobs rather than to a bare prefix list.
+_SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
+    # llms/openrouter/chat/transformation.py:36-49 — both under one ``if``
+    "openrouter/": ("reasoning_effort", "thinking"),
+    "groq/": ("reasoning_effort",),  # llms/groq/chat/transformation.py:107-110
+    "xai/": ("reasoning_effort",),  # llms/xai/chat/transformation.py:77-80
+    "deepinfra/": ("reasoning_effort",),  # llms/deepinfra/chat/transformation.py:80-84
+    "cerebras/": ("reasoning_effort",),  # llms/cerebras/chat.py:74-75
+    "fireworks_ai/": ("reasoning_effort",),  # llms/fireworks_ai/chat/transformation.py:121-122
+    "perplexity/": ("reasoning_effort",),  # llms/perplexity/chat/transformation.py:58-61
+    "bedrock_mantle/": ("reasoning_effort",),  # llms/bedrock_mantle/chat/transformation.py:55-59
+    "zai/": ("thinking",),  # llms/zai/chat/transformation.py:51-54
+    "minimax/": ("thinking",),  # llms/minimax/chat/transformation.py:97
+}
+
+# Provider prefix -> reasoning knobs that provider advertises UNCONDITIONALLY,
+# i.e. with no ``model_info`` needed and no model-map lookup involved.
+#
+# EMPTY BY DESIGN: no such provider has been verified yet. This is not the same
+# category as the map above — here ``model_info`` is unnecessary, there it is
+# required. A provider in neither map is one where the knob is popped silently
+# whatever the config says: ``TogetherAIConfig.get_supported_openai_params``
+# (``llms/together_ai/chat.py:18-46``) only *subtracts* from
+# ``OpenAIGPTConfig``'s base list, and that base list
+# (``llms/openai/chat/gpt_transformation.py:138-187``) carries no reasoning knob
+# under any condition. Add a prefix here only after reading that provider's
+# ``get_supported_openai_params`` against the pinned litellm version, and say
+# which version you checked.
+_UNCONDITIONAL_REASONING_KNOBS: dict[str, tuple[str, ...]] = {}
 
 
 def _load_model_list() -> list[dict]:
@@ -83,7 +114,20 @@ def _diverged_pairs(entries: list[dict], field: str) -> list[str]:
 
 
 def _entry_model(entry: dict) -> str:
-    return str((entry.get("litellm_params") or {}).get("model") or "")
+    """The provider-qualified model string for *entry*.
+
+    ``custom_llm_provider`` is an equally valid way to name the provider:
+    ``model: qwen/qwen3-max`` + ``custom_llm_provider: openrouter`` routes
+    exactly like ``model: openrouter/qwen/qwen3-max``. Normalise both spellings
+    to the prefixed form so provider lookup sees the same string either way —
+    otherwise the second shape falls through to the unverified-provider bucket
+    and gets advice written for a different provider."""
+    params = entry.get("litellm_params") or {}
+    model = str(params.get("model") or "")
+    provider = str(params.get("custom_llm_provider") or "")
+    if provider and not model.startswith(f"{provider}/"):
+        return f"{provider}/{model}"
+    return model
 
 
 def _reasoning_knobs_set(entry: dict) -> list[str]:
@@ -92,37 +136,47 @@ def _reasoning_knobs_set(entry: dict) -> list[str]:
     return [knob for knob in _REASONING_KNOBS if params.get(knob) is not None]
 
 
-def _reasoning_effort_offenders(entries: list[dict]) -> list[str]:
-    """Names of ``openrouter/*`` entries whose ``litellm_params`` reasoning knob
-    is a silent no-op: set, but without ``model_info.supports_reasoning`` to
-    make LiteLLM advertise the parameter as supported.
+def _knobs_for_provider(model: str, table: dict[str, tuple[str, ...]]) -> tuple[str, ...]:
+    """Knobs *table* records for the provider prefixing *model* (``()`` if none)."""
+    for prefix, knobs in table.items():
+        if model.startswith(prefix):
+            return knobs
+    return ()
 
-    Scoped to OpenRouter deliberately: ``supports_reasoning`` is the lever only
-    ``OpenrouterConfig`` pulls. Other providers are covered by
-    ``_unverified_provider_reasoning_effort`` below, because there the same
-    ``model_info`` block would be a placebo. See the class docstring below."""
+
+def _reasoning_knob_offenders(entries: list[dict]) -> list[str]:
+    """Names of entries whose ``litellm_params`` reasoning knob is a silent
+    no-op: set on a provider that gates it on ``litellm.supports_reasoning``,
+    but without ``model_info.supports_reasoning`` to satisfy that gate.
+
+    Keyed off ``_SUPPORTS_REASONING_GATED_KNOBS`` rather than a single provider,
+    because the gate is not OpenRouter-specific — nine other provider configs
+    use the identical fail-closed mechanism, and for all of them ``model_info``
+    is the working fix. Knobs the provider does not gate are not this
+    predicate's business; ``_unverified_provider_reasoning_knob`` has them."""
     return sorted(
         entry["model_name"]
         for entry in entries
-        if _entry_model(entry).startswith(_OPENROUTER_PREFIX)
-        and _reasoning_knobs_set(entry)
+        if set(_reasoning_knobs_set(entry))
+        & set(_knobs_for_provider(_entry_model(entry), _SUPPORTS_REASONING_GATED_KNOBS))
         and not (entry.get("model_info") or {}).get("supports_reasoning")
     )
 
 
-def _unverified_provider_reasoning_effort(entries: list[dict]) -> list[str]:
-    """Names of non-OpenRouter entries setting a reasoning knob on a provider
-    that has not been verified to advertise it.
+def _unverified_provider_reasoning_knob(entries: list[dict]) -> list[str]:
+    """Names of entries setting a reasoning knob their provider is not known to
+    advertise at all — neither gated on ``supports_reasoning`` nor
+    unconditional.
 
-    Deliberately ignores ``model_info``: outside OpenRouter it is not consulted,
-    so accepting it here would let the guard certify the exact defect it exists
-    to catch."""
+    Deliberately ignores ``model_info``: these providers never consult
+    ``litellm.supports_reasoning`` for this knob, so accepting the flag here
+    would let the guard certify the exact defect it exists to catch."""
     return sorted(
         entry["model_name"]
         for entry in entries
-        if not _entry_model(entry).startswith(_OPENROUTER_PREFIX)
-        and _reasoning_knobs_set(entry)
-        and not _entry_model(entry).startswith(_REASONING_EFFORT_NATIVE_PROVIDERS)
+        if set(_reasoning_knobs_set(entry))
+        - set(_knobs_for_provider(_entry_model(entry), _SUPPORTS_REASONING_GATED_KNOBS))
+        - set(_knobs_for_provider(_entry_model(entry), _UNCONDITIONAL_REASONING_KNOBS))
     )
 
 
@@ -202,8 +256,9 @@ class TestLitellmAliasInvariant:
 
 
 class TestReasoningEffortIsNotASilentNoop:
-    """On ``openrouter/*``, ``litellm_params.reasoning_effort`` reaches the wire
-    only when LiteLLM believes the model is reasoning-capable.
+    """On a ``supports_reasoning``-gated provider, ``litellm_params``'
+    reasoning knob reaches the wire only when LiteLLM believes the model is
+    reasoning-capable.
 
     ``OpenrouterConfig.get_supported_openai_params`` advertises
     ``reasoning_effort`` / ``thinking`` — both under the same ``if`` — only when
@@ -224,16 +279,19 @@ class TestReasoningEffortIsNotASilentNoop:
     ``extra_body.reasoning.effort``, which bypasses the mapper entirely. This
     guard pins the first form so the template cannot ship the silent no-op.
 
-    ``supports_reasoning`` is an OpenRouter-only lever, so the guard is scoped
-    to ``openrouter/*`` and other providers get their own check below: for them
-    a ``model_info`` block is a placebo, and one guard covering both would go
-    green on a config that still drops the parameter."""
+    The gate is **not** OpenRouter-specific: nine other provider configs use the
+    identical fail-closed mechanism, and the ``model_info`` fix works for all of
+    them because ``Router._create_deployment`` registers ``model_info`` into
+    ``litellm.model_cost`` under the raw ``litellm_params.model`` string
+    whatever the provider. ``_SUPPORTS_REASONING_GATED_KNOBS`` records which
+    knob each of them gates. Providers outside that map get the separate check
+    below, where ``model_info`` genuinely is a placebo."""
 
     def test_predicate_flags_the_silent_noop(self):
         # A guard that cannot fire is not a guard. Exercise it against the
         # exact shape #3599 reports in the wild: reasoning_effort set in
         # litellm_params, model not flagged.
-        assert _reasoning_effort_offenders(
+        assert _reasoning_knob_offenders(
             [
                 {
                     "model_name": "laguna-s-2.1",
@@ -244,7 +302,7 @@ class TestReasoningEffortIsNotASilentNoop:
 
     def test_predicate_accepts_the_flagged_form(self):
         assert (
-            _reasoning_effort_offenders(
+            _reasoning_knob_offenders(
                 [
                     {
                         "model_name": "ok",
@@ -260,7 +318,7 @@ class TestReasoningEffortIsNotASilentNoop:
         # The extra_body.reasoning form bypasses the mapper, so it needs no
         # model_info flag and must not be flagged as an offender.
         assert (
-            _reasoning_effort_offenders(
+            _reasoning_knob_offenders(
                 [
                     {
                         "model_name": "native",
@@ -277,7 +335,7 @@ class TestReasoningEffortIsNotASilentNoop:
     def test_predicate_flags_thinking_too(self):
         # `thinking` sits under the same `if litellm.supports_reasoning(...)`
         # in OpenrouterConfig, so an unflagged model drops it just as quietly.
-        assert _reasoning_effort_offenders(
+        assert _reasoning_knob_offenders(
             [
                 {
                     "model_name": "thinky",
@@ -286,12 +344,13 @@ class TestReasoningEffortIsNotASilentNoop:
             ]
         ) == ["thinky"]
 
-    def test_predicate_ignores_non_openrouter_providers(self):
-        # `supports_reasoning` is not consulted off OpenRouter, so this entry
-        # is not an offender *by this predicate's rule* — it is caught by
-        # TestReasoningEffortOffOpenrouter below, whose advice actually works.
+    def test_predicate_ignores_providers_that_never_advertise_the_knob(self):
+        # `TogetherAIConfig` does not consult `supports_reasoning` at all, so
+        # this entry is not an offender *by this predicate's rule* — demanding
+        # `model_info` here would be demanding a placebo. It is caught by
+        # TestReasoningKnobOnUnverifiedProvider below instead.
         assert (
-            _reasoning_effort_offenders(
+            _reasoning_knob_offenders(
                 [
                     {
                         "model_name": "together",
@@ -305,42 +364,115 @@ class TestReasoningEffortIsNotASilentNoop:
             == []
         )
 
+    def test_predicate_flags_non_openrouter_gated_providers(self):
+        # The gate is not OpenRouter-specific: groq/xai/deepinfra/cerebras/
+        # fireworks_ai/perplexity/bedrock_mantle gate `reasoning_effort` on the
+        # same `litellm.supports_reasoning` call, so an unflagged model there is
+        # the identical silent no-op — and `model_info` is the identical fix.
+        entries = [
+            {
+                "model_name": f"m-{prefix.strip('/')}",
+                "litellm_params": {"model": f"{prefix}vendor/model", "reasoning_effort": "high"},
+            }
+            for prefix in ("groq/", "xai/", "deepinfra/", "cerebras/")
+        ]
+        assert _reasoning_knob_offenders(entries) == [
+            "m-cerebras",
+            "m-deepinfra",
+            "m-groq",
+            "m-xai",
+        ]
+
+    def test_predicate_accepts_model_info_on_a_non_openrouter_gated_provider(self):
+        # The fix must work off OpenRouter too: `Router._create_deployment`
+        # registers `model_info` under the raw `groq/...` string, which is what
+        # `supports_reasoning(model, custom_llm_provider="groq")` reads back.
+        assert (
+            _reasoning_knob_offenders(
+                [
+                    {
+                        "model_name": "r1-distill",
+                        "litellm_params": {
+                            "model": "groq/deepseek-r1-distill-llama-70b",
+                            "reasoning_effort": "high",
+                        },
+                        "model_info": {"supports_reasoning": True},
+                    }
+                ]
+            )
+            == []
+        )
+
+    def test_predicate_is_per_knob_not_per_provider(self):
+        # `zai` gates `thinking` only and never advertises `reasoning_effort`,
+        # so `model_info` is the fix for the first knob and a placebo for the
+        # second. A per-provider rule would give one of them the wrong advice.
+        zai = {"model_name": "glm", "litellm_params": {"model": "zai/glm-4.6"}}
+        thinking = {**zai, "litellm_params": {**zai["litellm_params"], "thinking": {"type": "e"}}}
+        effort = {**zai, "litellm_params": {**zai["litellm_params"], "reasoning_effort": "high"}}
+        assert _reasoning_knob_offenders([thinking]) == ["glm"]
+        assert _unverified_provider_reasoning_knob([thinking]) == []
+        assert _reasoning_knob_offenders([effort]) == []
+        assert _unverified_provider_reasoning_knob([effort]) == ["glm"]
+
+    def test_predicate_reads_custom_llm_provider_form(self):
+        # `model: qwen/qwen3-max` + `custom_llm_provider: openrouter` routes
+        # exactly like the prefixed spelling and must land in the same bucket.
+        entry = {
+            "model_name": "qwen3-max",
+            "litellm_params": {
+                "model": "qwen/qwen3-max",
+                "custom_llm_provider": "openrouter",
+                "reasoning_effort": "high",
+            },
+        }
+        assert _reasoning_knob_offenders([entry]) == ["qwen3-max"]
+        assert _unverified_provider_reasoning_knob([entry]) == []
+
     def test_reasoning_effort_requires_supports_reasoning(self):
-        offenders = _reasoning_effort_offenders(_load_model_list())
+        offenders = _reasoning_knob_offenders(_load_model_list())
         assert not offenders, (
-            "`openrouter/*` model_list entries setting "
-            "`litellm_params.reasoning_effort` (or `thinking`) without "
-            f"`model_info.supports_reasoning: true`: {offenders} — LiteLLM "
-            "drops the parameter silently for any model missing from its "
-            "built-in model-cost map, so as written this is a no-op and the "
-            "agent runs at the provider's default depth. Either add "
-            "`model_info: {supports_reasoning: true}` to the entry, or use "
-            "OpenRouter's native `extra_body.reasoning.effort` instead. Pin "
-            "the flag even for a model currently in the map: map membership "
-            "changes under you on a litellm bump, the config does not."
+            "model_list entries setting `litellm_params.reasoning_effort` (or "
+            "`thinking`) on a provider that gates it on "
+            f"`litellm.supports_reasoning`, without `model_info`: {offenders} "
+            "— LiteLLM drops the parameter silently for any model missing from "
+            "its built-in model-cost map, so as written this is a no-op and "
+            "the agent runs at the provider's default depth. Add "
+            "`model_info: {supports_reasoning: true}` to the entry (it is "
+            "registered into the model-cost map under the raw "
+            "`litellm_params.model` string, so it satisfies the gate on every "
+            "provider in `_SUPPORTS_REASONING_GATED_KNOBS`), or on "
+            "`openrouter/*` use the native `extra_body.reasoning.effort` "
+            "instead. Pin the flag even for a model currently in the map: map "
+            "membership changes under you on a litellm bump, the config does not."
         )
 
 
-class TestReasoningEffortOffOpenrouter:
-    """Off OpenRouter, ``model_info.supports_reasoning`` is not the fix — it is
-    not read at all.
+class TestReasoningKnobOnUnverifiedProvider:
+    """Where a provider does not advertise the knob at all,
+    ``model_info.supports_reasoning`` is not the fix — it is not read.
 
-    Only ``OpenrouterConfig.get_supported_openai_params`` consults
-    ``litellm.supports_reasoning``. Every other provider answers from a static
-    list: ``TogetherAIConfig.get_supported_openai_params`` only *subtracts*
-    ``response_format`` / tool params from ``OpenAIGPTConfig``'s base list, and
-    that base list carries no ``reasoning_effort`` under any condition. So on a
-    ``together_ai/*`` route the parameter is popped silently whatever
-    ``model_info`` says — which is why these entries need a separate guard
-    rather than the OpenRouter one waved over them.
+    This is the complement of ``_SUPPORTS_REASONING_GATED_KNOBS``, not "anything
+    that isn't OpenRouter". ``TogetherAIConfig.get_supported_openai_params``
+    (``llms/together_ai/chat.py:18-46``) only *subtracts* ``response_format`` /
+    tool params from ``OpenAIGPTConfig``'s base list, and that base list carries
+    no reasoning knob under any condition — nothing there ever calls
+    ``litellm.supports_reasoning``. So on a ``together_ai/*`` route the
+    parameter is popped silently whatever ``model_info`` says, which is why
+    these entries need a separate guard rather than the gated-provider one
+    waved over them.
 
     There is no config-shaped fix to assert here, so the guard demands a
-    human-verified provider prefix in ``_REASONING_EFFORT_NATIVE_PROVIDERS``
-    instead: someone has to read that provider's ``get_supported_openai_params``
-    against the pinned litellm before the build goes green."""
+    human-verified entry in ``_UNCONDITIONAL_REASONING_KNOBS`` instead: someone
+    has to read that provider's ``get_supported_openai_params`` against the
+    pinned litellm before the build goes green. Note the two escape hatches are
+    not interchangeable — a provider that gates the knob belongs in
+    ``_SUPPORTS_REASONING_GATED_KNOBS`` (where ``model_info`` is then
+    *required*); listing it here instead would stop checking it entirely and let
+    the genuine silent no-op through."""
 
     def test_predicate_flags_an_unverified_provider(self):
-        assert _unverified_provider_reasoning_effort(
+        assert _unverified_provider_reasoning_knob(
             [
                 {
                     "model_name": "qwen3-coder-30b",
@@ -354,14 +486,19 @@ class TestReasoningEffortOffOpenrouter:
             ]
         ) == ["qwen3-coder-30b"]
 
-    def test_predicate_ignores_openrouter_entries(self):
+    def test_predicate_ignores_gated_provider_entries(self):
+        # These belong to the other guard, whose `model_info` advice works.
         assert (
-            _unverified_provider_reasoning_effort(
+            _unverified_provider_reasoning_knob(
                 [
                     {
                         "model_name": "or",
                         "litellm_params": {"model": "openrouter/x/y", "reasoning_effort": "high"},
-                    }
+                    },
+                    {
+                        "model_name": "groq",
+                        "litellm_params": {"model": "groq/x", "reasoning_effort": "high"},
+                    },
                 ]
             )
             == []
@@ -369,7 +506,7 @@ class TestReasoningEffortOffOpenrouter:
 
     def test_predicate_ignores_entries_without_a_reasoning_knob(self):
         assert (
-            _unverified_provider_reasoning_effort(
+            _unverified_provider_reasoning_knob(
                 [
                     {
                         "model_name": "plain",
@@ -383,19 +520,23 @@ class TestReasoningEffortOffOpenrouter:
             == []
         )
 
-    def test_no_reasoning_effort_on_unverified_providers(self):
-        offenders = _unverified_provider_reasoning_effort(_load_model_list())
+    def test_no_reasoning_knob_on_unverified_providers(self):
+        offenders = _unverified_provider_reasoning_knob(_load_model_list())
         assert not offenders, (
-            "non-`openrouter/*` model_list entries setting "
-            "`litellm_params.reasoning_effort` (or `thinking`) on a provider "
-            f"not listed in `_REASONING_EFFORT_NATIVE_PROVIDERS`: {offenders} "
-            "— `model_info.supports_reasoning` does NOT help here; it is an "
-            "OpenRouter-only mechanism, and most OpenAI-compatible provider "
-            "configs (together_ai among them) never advertise "
-            "`reasoning_effort`, so `drop_params: true` pops it silently. "
-            "Read that provider's `get_supported_openai_params` against the "
-            "pinned litellm version; if it does advertise the parameter, add "
-            "the prefix to `_REASONING_EFFORT_NATIVE_PROVIDERS` in this file "
-            "noting the version you checked. Otherwise drop the knob — there "
-            "is no config that makes it take effect."
+            "model_list entries setting `litellm_params.reasoning_effort` (or "
+            "`thinking`) on a provider not recorded in this file as "
+            f"advertising that knob: {offenders} — most OpenAI-compatible "
+            "provider configs (together_ai among them) never advertise it "
+            "under any condition, so `drop_params: true` pops it silently and "
+            "`model_info.supports_reasoning` does not help, because nothing on "
+            "that path reads it. Read that provider's "
+            "`get_supported_openai_params` against the pinned litellm version, "
+            "then: if it advertises the knob behind "
+            "`litellm.supports_reasoning`, add the prefix/knob to "
+            "`_SUPPORTS_REASONING_GATED_KNOBS` and set "
+            "`model_info: {supports_reasoning: true}` on the entry; if it "
+            "advertises the knob unconditionally, add it to "
+            "`_UNCONDITIONAL_REASONING_KNOBS`; note the version you checked "
+            "either way. Only if it advertises the knob nowhere is dropping it "
+            "the answer — there is then no config that makes it take effect."
         )

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -8,11 +8,13 @@ config copied to ``~/.config/egg/litellm-models.yaml``. Each routed
 suffix leaks — without the alias registered, LiteLLM 400s those probes
 with ``Invalid model name``.
 
-This test file enforces three guarantees: every bare row has its
-``[1m]`` alias, every ``[1m]`` alias has its bare sibling, and paired
-rows share equal ``litellm_params`` (compared as parsed YAML) — so
-probes and real requests can never be quietly routed through different
-configs. It catches a
+This test file enforces five guarantees: every bare row has its
+``[1m]`` alias, every ``[1m]`` alias has its bare sibling, paired rows
+share equal ``litellm_params`` and equal ``model_info`` (both compared
+as parsed YAML) — so probes and real requests can never be quietly
+routed through different configs — and no entry sets a reasoning knob
+(``reasoning_effort`` / ``thinking``) in a shape LiteLLM silently
+drops. It catches a
 forgetting operator who adds a new backend without its paired alias or
 lets the two rows' params drift. Commented-out example entries in the
 template are YAML comments, not parsed entries, so they're naturally
@@ -28,6 +30,27 @@ LITELLM_TEMPLATE = REPO_ROOT / "config" / "litellm-models.template.yaml"
 
 _ALIAS_SUFFIX = "[1m]"
 
+_OPENROUTER_PREFIX = "openrouter/"
+
+# Both knobs are appended under the same ``litellm.supports_reasoning``
+# condition in ``OpenrouterConfig.get_supported_openai_params``, so both are
+# dropped in the same silence for an unflagged model — guarding only
+# ``reasoning_effort`` would leave the identical trap open one key over.
+_REASONING_KNOBS = ("reasoning_effort", "thinking")
+
+# Non-OpenRouter provider prefixes whose LiteLLM chat config has been verified
+# to advertise ``reasoning_effort`` at all.
+#
+# EMPTY BY DESIGN. ``model_info.supports_reasoning`` is an OpenRouter-specific
+# mechanism: only ``OpenrouterConfig`` consults ``litellm.supports_reasoning``.
+# Other providers answer from a static list — e.g. ``TogetherAIConfig`` only
+# subtracts from ``OpenAIGPTConfig``'s base list, which contains no
+# ``reasoning_effort`` under any condition — so setting ``model_info`` there
+# changes nothing and the parameter is still popped silently. Add a prefix
+# here only after reading that provider's ``get_supported_openai_params``
+# against the pinned litellm version, and say which version you checked.
+_REASONING_EFFORT_NATIVE_PROVIDERS: tuple[str, ...] = ()
+
 
 def _load_model_list() -> list[dict]:
     """Return the live ``model_list`` entries in the template."""
@@ -42,25 +65,75 @@ def _load_model_names() -> set[str]:
     return {entry["model_name"] for entry in _load_model_list()}
 
 
+def _diverged_pairs(entries: list[dict], field: str) -> list[str]:
+    """Bare ``model_name``s whose ``[1m]`` sibling carries a different *field*.
+
+    ``field`` is a top-level key of a ``model_list`` entry (``litellm_params``,
+    ``model_info``); values are compared as parsed YAML. Rows with no ``[1m]``
+    sibling are not this predicate's business — ``test_every_bare_model_has_1m_alias``
+    already covers that."""
+    values = {entry["model_name"]: entry.get(field) for entry in entries}
+    return sorted(
+        name
+        for name, bare_value in values.items()
+        if not name.endswith(_ALIAS_SUFFIX)
+        and f"{name}{_ALIAS_SUFFIX}" in values
+        and values[f"{name}{_ALIAS_SUFFIX}"] != bare_value
+    )
+
+
+def _entry_model(entry: dict) -> str:
+    return str((entry.get("litellm_params") or {}).get("model") or "")
+
+
+def _reasoning_knobs_set(entry: dict) -> list[str]:
+    """Reasoning knobs this entry sets in ``litellm_params`` (possibly none)."""
+    params = entry.get("litellm_params") or {}
+    return [knob for knob in _REASONING_KNOBS if params.get(knob) is not None]
+
+
 def _reasoning_effort_offenders(entries: list[dict]) -> list[str]:
-    """Names of entries whose ``litellm_params.reasoning_effort`` is a silent
-    no-op: set, but without ``model_info.supports_reasoning`` to make LiteLLM
-    advertise the parameter as supported. See the class docstring below."""
+    """Names of ``openrouter/*`` entries whose ``litellm_params`` reasoning knob
+    is a silent no-op: set, but without ``model_info.supports_reasoning`` to
+    make LiteLLM advertise the parameter as supported.
+
+    Scoped to OpenRouter deliberately: ``supports_reasoning`` is the lever only
+    ``OpenrouterConfig`` pulls. Other providers are covered by
+    ``_unverified_provider_reasoning_effort`` below, because there the same
+    ``model_info`` block would be a placebo. See the class docstring below."""
     return sorted(
         entry["model_name"]
         for entry in entries
-        if (entry.get("litellm_params") or {}).get("reasoning_effort") is not None
+        if _entry_model(entry).startswith(_OPENROUTER_PREFIX)
+        and _reasoning_knobs_set(entry)
         and not (entry.get("model_info") or {}).get("supports_reasoning")
+    )
+
+
+def _unverified_provider_reasoning_effort(entries: list[dict]) -> list[str]:
+    """Names of non-OpenRouter entries setting a reasoning knob on a provider
+    that has not been verified to advertise it.
+
+    Deliberately ignores ``model_info``: outside OpenRouter it is not consulted,
+    so accepting it here would let the guard certify the exact defect it exists
+    to catch."""
+    return sorted(
+        entry["model_name"]
+        for entry in entries
+        if not _entry_model(entry).startswith(_OPENROUTER_PREFIX)
+        and _reasoning_knobs_set(entry)
+        and not _entry_model(entry).startswith(_REASONING_EFFORT_NATIVE_PROVIDERS)
     )
 
 
 class TestLitellmAliasInvariant:
     """Every bare ``model_name`` must have a paired ``<name>[1m]`` row,
-    and vice versa, and the two rows must share the same
-    ``litellm_params``. The symmetric naming errors — a bare row without
-    its alias, or an ``[1m]`` alias without its bare sibling — and a
-    ``litellm_params`` divergence between paired rows both mean probes
-    and real requests are served by different routing tables.
+    and vice versa, and the two rows must share both the same
+    ``litellm_params`` and the same ``model_info``. The symmetric naming
+    errors — a bare row without its alias, or an ``[1m]`` alias without
+    its bare sibling — and a divergence in either block between paired
+    rows all mean probes and real requests are served by different
+    routing tables.
     """
 
     def test_every_bare_model_has_1m_alias(self):
@@ -83,20 +156,34 @@ class TestLitellmAliasInvariant:
             "`litellm_params` (see #2832, #2841)"
         )
 
+    def test_diverged_pairs_flags_a_divergent_sibling(self):
+        # Every template entry's ``model_info`` is ``None`` today, so the two
+        # template-level parity tests below pass vacuously — exercise the
+        # shared predicate directly so a regression in it cannot hide.
+        entries = [
+            {"model_name": "m", "model_info": {"supports_reasoning": True}},
+            {"model_name": f"m{_ALIAS_SUFFIX}"},
+        ]
+        assert _diverged_pairs(entries, "model_info") == ["m"]
+
+    def test_diverged_pairs_accepts_matching_siblings(self):
+        entries = [
+            {"model_name": "m", "model_info": {"supports_reasoning": True}},
+            {"model_name": f"m{_ALIAS_SUFFIX}", "model_info": {"supports_reasoning": True}},
+        ]
+        assert _diverged_pairs(entries, "model_info") == []
+
+    def test_diverged_pairs_ignores_rows_without_a_sibling(self):
+        entries = [{"model_name": "lonely", "litellm_params": {"model": "openrouter/x/y"}}]
+        assert _diverged_pairs(entries, "litellm_params") == []
+
     def test_paired_rows_share_model_info(self):
         # ``model_info`` is a sibling of ``litellm_params``, so the params
-        # comparison above does not see it — but it carries
+        # comparison below does not see it — but it carries
         # ``supports_reasoning``, which decides whether ``reasoning_effort``
         # reaches the wire at all. Divergence here means the probe alias and
         # the real row run at different reasoning depths.
-        info = {entry["model_name"]: entry.get("model_info") for entry in _load_model_list()}
-        diverged = sorted(
-            name
-            for name, bare_info in info.items()
-            if not name.endswith(_ALIAS_SUFFIX)
-            and f"{name}{_ALIAS_SUFFIX}" in info
-            and info[f"{name}{_ALIAS_SUFFIX}"] != bare_info
-        )
+        diverged = _diverged_pairs(_load_model_list(), "model_info")
         assert not diverged, (
             "paired bare/`[1m]` rows with diverging `model_info`: "
             f"{diverged} — the `[1m]` alias must carry the same `model_info` "
@@ -105,14 +192,7 @@ class TestLitellmAliasInvariant:
         )
 
     def test_paired_rows_share_litellm_params(self):
-        params = {entry["model_name"]: entry.get("litellm_params") for entry in _load_model_list()}
-        diverged = sorted(
-            name
-            for name, bare_params in params.items()
-            if not name.endswith(_ALIAS_SUFFIX)
-            and f"{name}{_ALIAS_SUFFIX}" in params
-            and params[f"{name}{_ALIAS_SUFFIX}"] != bare_params
-        )
+        diverged = _diverged_pairs(_load_model_list(), "litellm_params")
         assert not diverged, (
             "paired bare/`[1m]` rows with diverging `litellm_params`: "
             f"{diverged} — the `[1m]` alias must point at the same "
@@ -122,14 +202,15 @@ class TestLitellmAliasInvariant:
 
 
 class TestReasoningEffortIsNotASilentNoop:
-    """``litellm_params.reasoning_effort`` reaches the wire only when LiteLLM
-    believes the model is reasoning-capable.
+    """On ``openrouter/*``, ``litellm_params.reasoning_effort`` reaches the wire
+    only when LiteLLM believes the model is reasoning-capable.
 
     ``OpenrouterConfig.get_supported_openai_params`` advertises
-    ``reasoning_effort`` / ``thinking`` only if ``litellm.supports_reasoning``
-    is true, and that reads LiteLLM's built-in model-cost map. A model absent
-    from the map answers False, so the gate fails closed and ``drop_params:
-    true`` then discards the parameter with no error and no log line.
+    ``reasoning_effort`` / ``thinking`` — both under the same ``if`` — only when
+    ``litellm.supports_reasoning`` is true, and that reads LiteLLM's built-in
+    model-cost map. A model absent from the map answers False, so the gate fails
+    closed and ``drop_params: true`` then discards the parameter with no error
+    and no log line.
 
     Absent is the normal state for an OpenRouter slug — verified against the
     pinned litellm 1.86.2, ``qwen/qwen3-max`` and
@@ -141,7 +222,12 @@ class TestReasoningEffortIsNotASilentNoop:
     The fix is ``model_info: {supports_reasoning: true}`` on the same entry
     (verified to put ``reasoning_effort`` on the wire), or OpenRouter's native
     ``extra_body.reasoning.effort``, which bypasses the mapper entirely. This
-    guard pins the first form so the template cannot ship the silent no-op."""
+    guard pins the first form so the template cannot ship the silent no-op.
+
+    ``supports_reasoning`` is an OpenRouter-only lever, so the guard is scoped
+    to ``openrouter/*`` and other providers get their own check below: for them
+    a ``model_info`` block is a placebo, and one guard covering both would go
+    green on a config that still drops the parameter."""
 
     def test_predicate_flags_the_silent_noop(self):
         # A guard that cannot fire is not a guard. Exercise it against the
@@ -188,14 +274,128 @@ class TestReasoningEffortIsNotASilentNoop:
             == []
         )
 
+    def test_predicate_flags_thinking_too(self):
+        # `thinking` sits under the same `if litellm.supports_reasoning(...)`
+        # in OpenrouterConfig, so an unflagged model drops it just as quietly.
+        assert _reasoning_effort_offenders(
+            [
+                {
+                    "model_name": "thinky",
+                    "litellm_params": {"model": "openrouter/x/y", "thinking": {"budget_tokens": 1}},
+                }
+            ]
+        ) == ["thinky"]
+
+    def test_predicate_ignores_non_openrouter_providers(self):
+        # `supports_reasoning` is not consulted off OpenRouter, so this entry
+        # is not an offender *by this predicate's rule* — it is caught by
+        # TestReasoningEffortOffOpenrouter below, whose advice actually works.
+        assert (
+            _reasoning_effort_offenders(
+                [
+                    {
+                        "model_name": "together",
+                        "litellm_params": {
+                            "model": "together_ai/Qwen/Qwen2.5-Coder-32B-Instruct",
+                            "reasoning_effort": "high",
+                        },
+                    }
+                ]
+            )
+            == []
+        )
+
     def test_reasoning_effort_requires_supports_reasoning(self):
         offenders = _reasoning_effort_offenders(_load_model_list())
         assert not offenders, (
-            "model_list entries setting `litellm_params.reasoning_effort` "
-            f"without `model_info.supports_reasoning: true`: {offenders} — "
-            "LiteLLM drops the parameter silently for any model it does not "
-            "believe is reasoning-capable, so as written this is a no-op and "
-            "the agent runs at the provider's default depth. Either add "
+            "`openrouter/*` model_list entries setting "
+            "`litellm_params.reasoning_effort` (or `thinking`) without "
+            f"`model_info.supports_reasoning: true`: {offenders} — LiteLLM "
+            "drops the parameter silently for any model missing from its "
+            "built-in model-cost map, so as written this is a no-op and the "
+            "agent runs at the provider's default depth. Either add "
             "`model_info: {supports_reasoning: true}` to the entry, or use "
-            "OpenRouter's native `extra_body.reasoning.effort` instead."
+            "OpenRouter's native `extra_body.reasoning.effort` instead. Pin "
+            "the flag even for a model currently in the map: map membership "
+            "changes under you on a litellm bump, the config does not."
+        )
+
+
+class TestReasoningEffortOffOpenrouter:
+    """Off OpenRouter, ``model_info.supports_reasoning`` is not the fix — it is
+    not read at all.
+
+    Only ``OpenrouterConfig.get_supported_openai_params`` consults
+    ``litellm.supports_reasoning``. Every other provider answers from a static
+    list: ``TogetherAIConfig.get_supported_openai_params`` only *subtracts*
+    ``response_format`` / tool params from ``OpenAIGPTConfig``'s base list, and
+    that base list carries no ``reasoning_effort`` under any condition. So on a
+    ``together_ai/*`` route the parameter is popped silently whatever
+    ``model_info`` says — which is why these entries need a separate guard
+    rather than the OpenRouter one waved over them.
+
+    There is no config-shaped fix to assert here, so the guard demands a
+    human-verified provider prefix in ``_REASONING_EFFORT_NATIVE_PROVIDERS``
+    instead: someone has to read that provider's ``get_supported_openai_params``
+    against the pinned litellm before the build goes green."""
+
+    def test_predicate_flags_an_unverified_provider(self):
+        assert _unverified_provider_reasoning_effort(
+            [
+                {
+                    "model_name": "qwen3-coder-30b",
+                    "litellm_params": {
+                        "model": "together_ai/Qwen/Qwen2.5-Coder-32B-Instruct",
+                        "reasoning_effort": "high",
+                    },
+                    # Present and useless — the point of the separate guard.
+                    "model_info": {"supports_reasoning": True},
+                }
+            ]
+        ) == ["qwen3-coder-30b"]
+
+    def test_predicate_ignores_openrouter_entries(self):
+        assert (
+            _unverified_provider_reasoning_effort(
+                [
+                    {
+                        "model_name": "or",
+                        "litellm_params": {"model": "openrouter/x/y", "reasoning_effort": "high"},
+                    }
+                ]
+            )
+            == []
+        )
+
+    def test_predicate_ignores_entries_without_a_reasoning_knob(self):
+        assert (
+            _unverified_provider_reasoning_effort(
+                [
+                    {
+                        "model_name": "plain",
+                        "litellm_params": {
+                            "model": "together_ai/Qwen/Qwen2.5-Coder-32B-Instruct",
+                            "drop_params": True,
+                        },
+                    }
+                ]
+            )
+            == []
+        )
+
+    def test_no_reasoning_effort_on_unverified_providers(self):
+        offenders = _unverified_provider_reasoning_effort(_load_model_list())
+        assert not offenders, (
+            "non-`openrouter/*` model_list entries setting "
+            "`litellm_params.reasoning_effort` (or `thinking`) on a provider "
+            f"not listed in `_REASONING_EFFORT_NATIVE_PROVIDERS`: {offenders} "
+            "— `model_info.supports_reasoning` does NOT help here; it is an "
+            "OpenRouter-only mechanism, and most OpenAI-compatible provider "
+            "configs (together_ai among them) never advertise "
+            "`reasoning_effort`, so `drop_params: true` pops it silently. "
+            "Read that provider's `get_supported_openai_params` against the "
+            "pinned litellm version; if it does advertise the parameter, add "
+            "the prefix to `_REASONING_EFFORT_NATIVE_PROVIDERS` in this file "
+            "noting the version you checked. Otherwise drop the knob — there "
+            "is no config that makes it take effect."
         )

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -42,6 +42,18 @@ def _load_model_names() -> set[str]:
     return {entry["model_name"] for entry in _load_model_list()}
 
 
+def _reasoning_effort_offenders(entries: list[dict]) -> list[str]:
+    """Names of entries whose ``litellm_params.reasoning_effort`` is a silent
+    no-op: set, but without ``model_info.supports_reasoning`` to make LiteLLM
+    advertise the parameter as supported. See the class docstring below."""
+    return sorted(
+        entry["model_name"]
+        for entry in entries
+        if (entry.get("litellm_params") or {}).get("reasoning_effort") is not None
+        and not (entry.get("model_info") or {}).get("supports_reasoning")
+    )
+
+
 class TestLitellmAliasInvariant:
     """Every bare ``model_name`` must have a paired ``<name>[1m]`` row,
     and vice versa, and the two rows must share the same
@@ -71,6 +83,27 @@ class TestLitellmAliasInvariant:
             "`litellm_params` (see #2832, #2841)"
         )
 
+    def test_paired_rows_share_model_info(self):
+        # ``model_info`` is a sibling of ``litellm_params``, so the params
+        # comparison above does not see it — but it carries
+        # ``supports_reasoning``, which decides whether ``reasoning_effort``
+        # reaches the wire at all. Divergence here means the probe alias and
+        # the real row run at different reasoning depths.
+        info = {entry["model_name"]: entry.get("model_info") for entry in _load_model_list()}
+        diverged = sorted(
+            name
+            for name, bare_info in info.items()
+            if not name.endswith(_ALIAS_SUFFIX)
+            and f"{name}{_ALIAS_SUFFIX}" in info
+            and info[f"{name}{_ALIAS_SUFFIX}"] != bare_info
+        )
+        assert not diverged, (
+            "paired bare/`[1m]` rows with diverging `model_info`: "
+            f"{diverged} — the `[1m]` alias must carry the same `model_info` "
+            "as its bare sibling (notably `supports_reasoning`, which gates "
+            "whether `reasoning_effort` is sent at all)"
+        )
+
     def test_paired_rows_share_litellm_params(self):
         params = {entry["model_name"]: entry.get("litellm_params") for entry in _load_model_list()}
         diverged = sorted(
@@ -85,4 +118,84 @@ class TestLitellmAliasInvariant:
             f"{diverged} — the `[1m]` alias must point at the same "
             "`litellm_params` as its bare sibling, or probes and real "
             "requests are quietly served by different configs (see #2832, #2841)"
+        )
+
+
+class TestReasoningEffortIsNotASilentNoop:
+    """``litellm_params.reasoning_effort`` reaches the wire only when LiteLLM
+    believes the model is reasoning-capable.
+
+    ``OpenrouterConfig.get_supported_openai_params`` advertises
+    ``reasoning_effort`` / ``thinking`` only if ``litellm.supports_reasoning``
+    is true, and that reads LiteLLM's built-in model-cost map. A model absent
+    from the map answers False, so the gate fails closed and ``drop_params:
+    true`` then discards the parameter with no error and no log line.
+
+    Absent is the normal state for an OpenRouter slug — verified against the
+    pinned litellm 1.86.2, ``qwen/qwen3-max`` and
+    ``moonshotai/kimi-k2-thinking`` are both absent and answer False, while
+    ``deepseek/deepseek-r1`` is present and answers True. So the failure mode
+    is not exotic: set ``reasoning_effort`` on a new slug and the agent
+    silently runs at the provider's default depth.
+
+    The fix is ``model_info: {supports_reasoning: true}`` on the same entry
+    (verified to put ``reasoning_effort`` on the wire), or OpenRouter's native
+    ``extra_body.reasoning.effort``, which bypasses the mapper entirely. This
+    guard pins the first form so the template cannot ship the silent no-op."""
+
+    def test_predicate_flags_the_silent_noop(self):
+        # A guard that cannot fire is not a guard. Exercise it against the
+        # exact shape #3599 reports in the wild: reasoning_effort set in
+        # litellm_params, model not flagged.
+        assert _reasoning_effort_offenders(
+            [
+                {
+                    "model_name": "laguna-s-2.1",
+                    "litellm_params": {"model": "openrouter/x/y", "reasoning_effort": "high"},
+                }
+            ]
+        ) == ["laguna-s-2.1"]
+
+    def test_predicate_accepts_the_flagged_form(self):
+        assert (
+            _reasoning_effort_offenders(
+                [
+                    {
+                        "model_name": "ok",
+                        "litellm_params": {"model": "openrouter/x/y", "reasoning_effort": "high"},
+                        "model_info": {"supports_reasoning": True},
+                    }
+                ]
+            )
+            == []
+        )
+
+    def test_predicate_ignores_entries_not_setting_reasoning_effort(self):
+        # The extra_body.reasoning form bypasses the mapper, so it needs no
+        # model_info flag and must not be flagged as an offender.
+        assert (
+            _reasoning_effort_offenders(
+                [
+                    {
+                        "model_name": "native",
+                        "litellm_params": {
+                            "model": "openrouter/x/y",
+                            "extra_body": {"reasoning": {"effort": "high"}},
+                        },
+                    }
+                ]
+            )
+            == []
+        )
+
+    def test_reasoning_effort_requires_supports_reasoning(self):
+        offenders = _reasoning_effort_offenders(_load_model_list())
+        assert not offenders, (
+            "model_list entries setting `litellm_params.reasoning_effort` "
+            f"without `model_info.supports_reasoning: true`: {offenders} — "
+            "LiteLLM drops the parameter silently for any model it does not "
+            "believe is reasoning-capable, so as written this is a no-op and "
+            "the agent runs at the provider's default depth. Either add "
+            "`model_info: {supports_reasoning: true}` to the entry, or use "
+            "OpenRouter's native `extra_body.reasoning.effort` instead."
         )

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -8,26 +8,38 @@ config copied to ``~/.config/egg/litellm-models.yaml``. Each routed
 suffix leaks — without the alias registered, LiteLLM 400s those probes
 with ``Invalid model name``.
 
-This test file enforces five guarantees: every bare row has its
+This test file enforces six guarantees: every bare row has its
 ``[1m]`` alias, every ``[1m]`` alias has its bare sibling, paired rows
 share equal ``litellm_params`` and equal ``model_info`` (both compared
 as parsed YAML) — so probes and real requests can never be quietly
-routed through different configs — and no entry sets a reasoning knob
-(``reasoning_effort`` / ``thinking``) in a shape LiteLLM silently drops.
-It catches a forgetting operator who adds a new backend without its
-paired alias or lets the two rows' params drift. Commented-out example
-entries in the template are YAML comments, not parsed entries, so
-they're naturally excluded.
+routed through different configs — no entry sets a reasoning knob
+(``reasoning_effort`` / ``thinking``) in a shape LiteLLM silently drops,
+and the litellm version the provider tables below were read against is
+still the version the image pins. It catches a forgetting operator who
+adds a new backend without its paired alias or lets the two rows' params
+drift. Commented-out example entries in the template are YAML comments,
+not parsed entries, so they're naturally excluded.
 """
 
+import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 LITELLM_TEMPLATE = REPO_ROOT / "config" / "litellm-models.template.yaml"
+LITELLM_DOCKERFILE = REPO_ROOT / "config" / "litellm" / "Dockerfile"
 
 _ALIAS_SUFFIX = "[1m]"
+
+# The litellm version every provider-config claim in this file was read
+# against. ``test_provider_tables_match_the_pinned_litellm`` fails the build if
+# the image is bumped past it, because which providers gate a reasoning knob —
+# and on what — is version-specific: providers get added, and a gate can flip
+# from fail-closed to fail-open in a patch release. A bump means re-reading the
+# ``get_supported_openai_params`` of each prefix below, then moving this string.
+_VERIFIED_LITELLM_VERSION = "1.86.2"
 
 # The reasoning knobs LiteLLM can silently drop. Both are appended under the
 # same ``litellm.supports_reasoning`` condition in
@@ -37,25 +49,60 @@ _ALIAS_SUFFIX = "[1m]"
 _REASONING_KNOBS = ("reasoning_effort", "thinking")
 
 # Provider prefix -> the reasoning knobs that provider's LiteLLM chat config
-# advertises ONLY when ``litellm.supports_reasoning(model, provider)`` is true.
+# decides to advertise by consulting ``litellm.supports_reasoning(model, …)``.
 #
-# For these prefix/knob combinations, and only these, ``model_info:
-# {supports_reasoning: true}`` on the entry is the fix: ``Router._create_deployment``
-# registers the entry's ``model_info`` into ``litellm.model_cost`` keyed by the
-# raw ``litellm_params.model`` string (``litellm/router.py:7911-7923``), which is
-# exactly what ``supports_reasoning`` reads back. Nothing in that path is
-# OpenRouter-specific.
+# For these prefix/knob combinations ``model_info: {supports_reasoning: true}``
+# on the entry is the thing that makes the knob reach the wire:
+# ``Router._create_deployment`` registers the entry's ``model_info`` into
+# ``litellm.model_cost`` (``litellm/router.py:7186-7215``, mirrored for
+# dynamically added deployments at ``:7897-7923``), which is exactly what
+# ``supports_reasoning`` → ``_get_model_info_helper`` reads back
+# (``litellm/utils.py:2775-2781``). Nothing in that path is OpenRouter-specific.
+#
+# CLASSIFY BY SHAPE, NOT BY COUNT. A hard count ("nine providers do this") is a
+# claim that rots on every litellm bump and tells you nothing about the entry in
+# front of you. Read the provider's ``get_supported_openai_params`` and ask what
+# it does when the model is ABSENT from LiteLLM's map. Three shapes appear at
+# the pinned version, all of which want ``model_info`` set:
+#
+#   (a) pure gate — the ``supports_reasoning`` call is the only condition, so
+#       an unmapped model fails closed and the knob is dropped in silence.
+#       ``model_info`` is REQUIRED. Most rows below are this shape.
+#   (b) gate AND a name heuristic — ``github_copilot`` advertises the knobs
+#       only for a model whose name contains "claude" *and* which answers the
+#       gate. ``model_info`` is necessary but not sufficient there.
+#   (c) name heuristics OR gate — ``anthropic`` and ``bedrock`` (converse) let
+#       a recognised name (``claude-3-7``, ``claude-sonnet-4``, ``deepseek.r1``,
+#       …) through without consulting the map at all, and fall back to the gate
+#       for every other name. ``model_info`` is what carries those other names;
+#       on a recognised name it is merely redundant.
+#
+# The contrast case, and the reason the shape matters more than the call:
+# azure's o-series config calls ``supports_reasoning`` too
+# (``llms/azure/chat/o_series_transformation.py:49-71``) but FAILS OPEN — a
+# deployment name absent from LiteLLM's map is *assumed* reasoning-capable and
+# gets ``reasoning_effort`` advertised unconditionally. Same call, opposite
+# failure mode. So "calls ``supports_reasoning``" is not the test; "what happens
+# when the model is absent" is.
+#
+# When a provider's shape is unclear, put it here rather than in
+# ``_UNCONDITIONAL_REASONING_KNOBS``: demanding ``model_info`` never suppresses
+# a knob that would otherwise be sent, whereas the other table stops checking
+# the entry altogether.
 #
 # Verified by reading each ``get_supported_openai_params`` at the pinned litellm
-# **v1.86.2** (``config/litellm/Dockerfile``). This set moves on a version bump —
-# re-read the configs and update the version noted here when you bump.
+# (``_VERIFIED_LITELLM_VERSION``); line numbers are from that tag.
 #
 # Note the knob column: ``zai`` and ``minimax`` gate ``thinking`` only and never
 # advertise ``reasoning_effort`` at all, so a per-provider tuple would be wrong
 # for them. That is why this maps to knobs rather than to a bare prefix list.
 _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
-    # llms/openrouter/chat/transformation.py:36-49 — both under one ``if``
-    "openrouter/": ("reasoning_effort", "thinking"),
+    # (a) pure gate, both knobs under one ``if``
+    "openrouter/": ("reasoning_effort", "thinking"),  # llms/openrouter/chat/transformation.py:41-48
+    "gemini/": ("reasoning_effort", "thinking"),  # llms/gemini/chat/transformation.py:96-98
+    # llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py:328-330
+    "vertex_ai/": ("reasoning_effort", "thinking"),
+    # (a) pure gate, one knob
     "groq/": ("reasoning_effort",),  # llms/groq/chat/transformation.py:107-110
     "xai/": ("reasoning_effort",),  # llms/xai/chat/transformation.py:77-80
     "deepinfra/": ("reasoning_effort",),  # llms/deepinfra/chat/transformation.py:80-84
@@ -65,13 +112,24 @@ _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
     "bedrock_mantle/": ("reasoning_effort",),  # llms/bedrock_mantle/chat/transformation.py:55-59
     "zai/": ("thinking",),  # llms/zai/chat/transformation.py:51-54
     "minimax/": ("thinking",),  # llms/minimax/chat/transformation.py:97
+    # (b) gate AND ``"claude" in model``
+    # llms/github_copilot/chat/transformation.py:122-129
+    "github_copilot/": ("reasoning_effort", "thinking"),
+    # (c) name heuristics OR gate
+    "anthropic/": ("reasoning_effort", "thinking"),  # llms/anthropic/chat/transformation.py:454-464
+    # llms/bedrock/chat/converse_transformation.py:556-575
+    "bedrock/": ("reasoning_effort", "thinking"),
 }
 
 # Provider prefix -> reasoning knobs that provider advertises UNCONDITIONALLY,
 # i.e. with no ``model_info`` needed and no model-map lookup involved.
 #
-# EMPTY BY DESIGN: no such provider has been verified yet. This is not the same
-# category as the map above — here ``model_info`` is unnecessary, there it is
+# EMPTY BY DESIGN: no such provider has been verified yet. Azure's o-series
+# config is the closest candidate (it advertises ``reasoning_effort`` for any
+# deployment name absent from LiteLLM's map) but is *conditionally* fail-open —
+# a mapped, non-reasoning deployment name is still gated — so it is deliberately
+# left out rather than half-recorded here. This is not the same category as the
+# map above — here ``model_info`` is unnecessary, there it is
 # required. A provider in neither map is one where the knob is popped silently
 # whatever the config says: ``TogetherAIConfig.get_supported_openai_params``
 # (``llms/together_ai/chat.py:18-46``) only *subtracts* from
@@ -114,20 +172,53 @@ def _diverged_pairs(entries: list[dict], field: str) -> list[str]:
 
 
 def _entry_model(entry: dict) -> str:
-    """The provider-qualified model string for *entry*.
+    """The provider-qualified model key request-time lookup resolves to.
 
     ``custom_llm_provider`` is an equally valid way to name the provider:
     ``model: qwen/qwen3-max`` + ``custom_llm_provider: openrouter`` routes
     exactly like ``model: openrouter/qwen/qwen3-max``. Normalise both spellings
     to the prefixed form so provider lookup sees the same string either way —
     otherwise the second shape falls through to the unverified-provider bucket
-    and gets advice written for a different provider."""
+    and gets advice written for a different provider.
+
+    This mirrors the *read* side: ``get_llm_provider`` strips a provider prefix
+    the model already carries, and ``_get_potential_model_names`` then re-adds
+    the provider exactly once (``litellm/utils.py:5551-5586``). The *write* side
+    differs — see ``_registered_model_key``."""
     params = entry.get("litellm_params") or {}
     model = str(params.get("model") or "")
     provider = str(params.get("custom_llm_provider") or "")
     if provider and not model.startswith(f"{provider}/"):
         return f"{provider}/{model}"
     return model
+
+
+def _registered_model_key(entry: dict) -> str:
+    """The model-cost-map key LiteLLM files this entry's ``model_info`` under.
+
+    ``Router._create_deployment`` prepends ``custom_llm_provider`` to
+    ``litellm_params.model`` **unconditionally** when that field is set
+    (``litellm/router.py:7195-7199``, mirrored at ``:7903-7907``); it does not
+    check whether the model string already carries the prefix. So this is *not*
+    always the same key ``_entry_model`` resolves — see
+    ``_model_info_reaches_the_gate``."""
+    params = entry.get("litellm_params") or {}
+    model = str(params.get("model") or "")
+    provider = str(params.get("custom_llm_provider") or "")
+    return f"{provider}/{model}" if provider else model
+
+
+def _model_info_reaches_the_gate(entry: dict) -> bool:
+    """Whether this entry's ``model_info`` lands on the key the gate reads back.
+
+    Spelling the provider twice — ``model: openrouter/qwen/qwen3-max`` *plus*
+    ``custom_llm_provider: openrouter`` — registers ``model_info`` under
+    ``openrouter/openrouter/qwen/qwen3-max`` (unconditional prepend) while the
+    gate looks up ``openrouter/qwen/qwen3-max`` (prefix stripped, then re-added
+    once). The flag is written and read at different keys, so
+    ``supports_reasoning`` still answers False and the knob is still dropped in
+    silence — with the config now *looking* correct. Spell the provider once."""
+    return _registered_model_key(entry) == _entry_model(entry)
 
 
 def _reasoning_knobs_set(entry: dict) -> list[str]:
@@ -150,16 +241,23 @@ def _reasoning_knob_offenders(entries: list[dict]) -> list[str]:
     but without ``model_info.supports_reasoning`` to satisfy that gate.
 
     Keyed off ``_SUPPORTS_REASONING_GATED_KNOBS`` rather than a single provider,
-    because the gate is not OpenRouter-specific — nine other provider configs
-    use the identical fail-closed mechanism, and for all of them ``model_info``
-    is the working fix. Knobs the provider does not gate are not this
-    predicate's business; ``_unverified_provider_reasoning_knob`` has them."""
+    because the gate is not OpenRouter-specific — a range of other provider
+    configs consult the same call, and for all of them ``model_info`` is what
+    satisfies it. Knobs the provider does not gate are not this predicate's
+    business; ``_unverified_provider_reasoning_knob`` has them.
+
+    ``model_info`` only counts when it lands on the key the gate reads
+    (``_model_info_reaches_the_gate``): a double-spelled provider registers it
+    somewhere nothing looks, which is a silent no-op wearing the fix's clothes."""
     return sorted(
         entry["model_name"]
         for entry in entries
         if set(_reasoning_knobs_set(entry))
         & set(_knobs_for_provider(_entry_model(entry), _SUPPORTS_REASONING_GATED_KNOBS))
-        and not (entry.get("model_info") or {}).get("supports_reasoning")
+        and not (
+            (entry.get("model_info") or {}).get("supports_reasoning")
+            and _model_info_reaches_the_gate(entry)
+        )
     )
 
 
@@ -255,7 +353,7 @@ class TestLitellmAliasInvariant:
         )
 
 
-class TestReasoningEffortIsNotASilentNoop:
+class TestReasoningKnobIsNotASilentNoop:
     """On a ``supports_reasoning``-gated provider, ``litellm_params``'
     reasoning knob reaches the wire only when LiteLLM believes the model is
     reasoning-capable.
@@ -279,13 +377,17 @@ class TestReasoningEffortIsNotASilentNoop:
     ``extra_body.reasoning.effort``, which bypasses the mapper entirely. This
     guard pins the first form so the template cannot ship the silent no-op.
 
-    The gate is **not** OpenRouter-specific: nine other provider configs use the
-    identical fail-closed mechanism, and the ``model_info`` fix works for all of
-    them because ``Router._create_deployment`` registers ``model_info`` into
-    ``litellm.model_cost`` under the raw ``litellm_params.model`` string
-    whatever the provider. ``_SUPPORTS_REASONING_GATED_KNOBS`` records which
-    knob each of them gates. Providers outside that map get the separate check
-    below, where ``model_info`` genuinely is a placebo."""
+    The gate is **not** OpenRouter-specific. A range of other provider configs
+    consult the same ``litellm.supports_reasoning`` call when deciding whether
+    to advertise a reasoning knob — ``gemini`` and ``vertex_ai`` with exactly
+    OpenRouter's fail-closed shape, ``anthropic`` / ``bedrock`` /
+    ``github_copilot`` in combination with a model-name heuristic — and on all
+    of them ``model_info`` is what satisfies it, because
+    ``Router._create_deployment`` registers ``model_info`` into
+    ``litellm.model_cost`` under a key built from ``litellm_params``, nothing
+    provider-specific. ``_SUPPORTS_REASONING_GATED_KNOBS`` records which knob
+    each of them gates and which shape it is. Providers outside that map get the
+    separate check below, where ``model_info`` genuinely is a placebo."""
 
     def test_predicate_flags_the_silent_noop(self):
         # A guard that cannot fire is not a guard. Exercise it against the
@@ -364,44 +466,51 @@ class TestReasoningEffortIsNotASilentNoop:
             == []
         )
 
-    def test_predicate_flags_non_openrouter_gated_providers(self):
-        # The gate is not OpenRouter-specific: groq/xai/deepinfra/cerebras/
-        # fireworks_ai/perplexity/bedrock_mantle gate `reasoning_effort` on the
-        # same `litellm.supports_reasoning` call, so an unflagged model there is
-        # the identical silent no-op — and `model_info` is the identical fix.
-        entries = [
-            {
-                "model_name": f"m-{prefix.strip('/')}",
-                "litellm_params": {"model": f"{prefix}vendor/model", "reasoning_effort": "high"},
-            }
-            for prefix in ("groq/", "xai/", "deepinfra/", "cerebras/")
-        ]
-        assert _reasoning_knob_offenders(entries) == [
-            "m-cerebras",
-            "m-deepinfra",
-            "m-groq",
-            "m-xai",
-        ]
+    @pytest.mark.parametrize(
+        ("prefix", "knob"),
+        [
+            (prefix, knob)
+            for prefix, knobs in sorted(_SUPPORTS_REASONING_GATED_KNOBS.items())
+            for knob in knobs
+        ],
+    )
+    def test_every_gated_row_demands_model_info_and_accepts_it(self, prefix, knob):
+        # One case per (prefix, knob) pair in the table, so a row added without
+        # thinking cannot ride in untested — and the per-knob splits (`zai` and
+        # `minimax` gate `thinking` only) are exercised rather than assumed.
+        # `model_info` is the fix on every one of them: the registration path
+        # (`Router._create_deployment` -> `litellm.model_cost`) is not
+        # provider-specific.
+        bare = {
+            "model_name": "m",
+            "litellm_params": {"model": f"{prefix}vendor/model", knob: "high"},
+        }
+        assert _reasoning_knob_offenders([bare]) == ["m"]
+        assert _unverified_provider_reasoning_knob([bare]) == []
+        flagged = {**bare, "model_info": {"supports_reasoning": True}}
+        assert _reasoning_knob_offenders([flagged]) == []
+        assert _unverified_provider_reasoning_knob([flagged]) == []
 
-    def test_predicate_accepts_model_info_on_a_non_openrouter_gated_provider(self):
-        # The fix must work off OpenRouter too: `Router._create_deployment`
-        # registers `model_info` under the raw `groq/...` string, which is what
-        # `supports_reasoning(model, custom_llm_provider="groq")` reads back.
-        assert (
-            _reasoning_knob_offenders(
-                [
-                    {
-                        "model_name": "r1-distill",
-                        "litellm_params": {
-                            "model": "groq/deepseek-r1-distill-llama-70b",
-                            "reasoning_effort": "high",
-                        },
-                        "model_info": {"supports_reasoning": True},
-                    }
-                ]
-            )
-            == []
-        )
+    @pytest.mark.parametrize(
+        ("prefix", "knob"),
+        [
+            (prefix, knob)
+            for prefix, knobs in sorted(_SUPPORTS_REASONING_GATED_KNOBS.items())
+            for knob in _REASONING_KNOBS
+            if knob not in knobs
+        ],
+    )
+    def test_knobs_a_gated_provider_does_not_advertise_get_the_other_guard(self, prefix, knob):
+        # The complement of the case above: a knob this provider never
+        # advertises is not fixable with `model_info`, so it must land in the
+        # unverified bucket instead of being told to set a placebo.
+        entry = {
+            "model_name": "m",
+            "litellm_params": {"model": f"{prefix}vendor/model", knob: "high"},
+            "model_info": {"supports_reasoning": True},
+        }
+        assert _reasoning_knob_offenders([entry]) == []
+        assert _unverified_provider_reasoning_knob([entry]) == ["m"]
 
     def test_predicate_is_per_knob_not_per_provider(self):
         # `zai` gates `thinking` only and never advertises `reasoning_effort`,
@@ -429,22 +538,50 @@ class TestReasoningEffortIsNotASilentNoop:
         assert _reasoning_knob_offenders([entry]) == ["qwen3-max"]
         assert _unverified_provider_reasoning_knob([entry]) == []
 
-    def test_reasoning_effort_requires_supports_reasoning(self):
+    def test_predicate_flags_a_double_spelled_provider(self):
+        # `model:` already prefixed AND `custom_llm_provider:` set is the one
+        # shape where `model_info` is present and still does nothing: litellm
+        # registers it under `openrouter/openrouter/...` (unconditional prepend)
+        # while the gate reads `openrouter/...`. Green here would certify a
+        # config that looks fixed and is not.
+        entry = {
+            "model_name": "qwen3-max",
+            "litellm_params": {
+                "model": "openrouter/qwen/qwen3-max",
+                "custom_llm_provider": "openrouter",
+                "reasoning_effort": "high",
+            },
+            "model_info": {"supports_reasoning": True},
+        }
+        assert _reasoning_knob_offenders([entry]) == ["qwen3-max"]
+        # Dropping the redundant provider spelling is the fix.
+        deduped = {
+            **entry,
+            "litellm_params": {
+                k: v for k, v in entry["litellm_params"].items() if k != "custom_llm_provider"
+            },
+        }
+        assert _reasoning_knob_offenders([deduped]) == []
+
+    def test_reasoning_knob_requires_supports_reasoning(self):
         offenders = _reasoning_knob_offenders(_load_model_list())
         assert not offenders, (
             "model_list entries setting `litellm_params.reasoning_effort` (or "
             "`thinking`) on a provider that gates it on "
-            f"`litellm.supports_reasoning`, without `model_info`: {offenders} "
-            "— LiteLLM drops the parameter silently for any model missing from "
-            "its built-in model-cost map, so as written this is a no-op and "
-            "the agent runs at the provider's default depth. Add "
+            f"`litellm.supports_reasoning`, without effective `model_info`: "
+            f"{offenders} — LiteLLM drops the parameter silently for any model "
+            "missing from its built-in model-cost map, so as written this is a "
+            "no-op and the agent runs at the provider's default depth. Add "
             "`model_info: {supports_reasoning: true}` to the entry (it is "
-            "registered into the model-cost map under the raw "
-            "`litellm_params.model` string, so it satisfies the gate on every "
-            "provider in `_SUPPORTS_REASONING_GATED_KNOBS`), or on "
-            "`openrouter/*` use the native `extra_body.reasoning.effort` "
-            "instead. Pin the flag even for a model currently in the map: map "
-            "membership changes under you on a litellm bump, the config does not."
+            "registered into the model-cost map under a key built from "
+            "`litellm_params`, so it satisfies the gate on every provider in "
+            "`_SUPPORTS_REASONING_GATED_KNOBS`), or on `openrouter/*` use the "
+            "native `extra_body.reasoning.effort` instead. Pin the flag even "
+            "for a model currently in the map: map membership changes under you "
+            "on a litellm bump, the config does not. If the entry already "
+            "carries the flag, check you have not spelled the provider twice — "
+            "a prefixed `model:` plus `custom_llm_provider:` registers "
+            "`model_info` under a doubled prefix that nothing reads back."
         )
 
 
@@ -463,13 +600,17 @@ class TestReasoningKnobOnUnverifiedProvider:
     waved over them.
 
     There is no config-shaped fix to assert here, so the guard demands a
-    human-verified entry in ``_UNCONDITIONAL_REASONING_KNOBS`` instead: someone
-    has to read that provider's ``get_supported_openai_params`` against the
-    pinned litellm before the build goes green. Note the two escape hatches are
-    not interchangeable — a provider that gates the knob belongs in
+    human-verified entry in one of the two tables instead: someone has to read
+    that provider's ``get_supported_openai_params`` against the pinned litellm
+    before the build goes green. The two escape hatches are not interchangeable
+    — a provider that consults ``litellm.supports_reasoning`` at all belongs in
     ``_SUPPORTS_REASONING_GATED_KNOBS`` (where ``model_info`` is then
-    *required*); listing it here instead would stop checking it entirely and let
-    the genuine silent no-op through."""
+    *required*); listing it in ``_UNCONDITIONAL_REASONING_KNOBS`` instead would
+    stop checking it entirely and let the genuine silent no-op through. When in
+    doubt, the gated table is the fail-safe classification.
+
+    Being in neither table means "nobody has read this provider's config yet",
+    not "this provider is broken" — the guard fails closed on ignorance."""
 
     def test_predicate_flags_an_unverified_provider(self):
         assert _unverified_provider_reasoning_knob(
@@ -524,19 +665,54 @@ class TestReasoningKnobOnUnverifiedProvider:
         offenders = _unverified_provider_reasoning_knob(_load_model_list())
         assert not offenders, (
             "model_list entries setting `litellm_params.reasoning_effort` (or "
-            "`thinking`) on a provider not recorded in this file as "
-            f"advertising that knob: {offenders} — most OpenAI-compatible "
-            "provider configs (together_ai among them) never advertise it "
-            "under any condition, so `drop_params: true` pops it silently and "
-            "`model_info.supports_reasoning` does not help, because nothing on "
-            "that path reads it. Read that provider's "
-            "`get_supported_openai_params` against the pinned litellm version, "
-            "then: if it advertises the knob behind "
-            "`litellm.supports_reasoning`, add the prefix/knob to "
+            "`thinking`) on a provider/knob pair no table in this file records: "
+            f"{offenders} — nobody has read that provider's chat config yet, so "
+            "the guard fails closed rather than guessing. Many "
+            "OpenAI-compatible configs (together_ai among them) never advertise "
+            "the knob under any condition, and there `drop_params: true` pops "
+            "it silently and `model_info.supports_reasoning` cannot help "
+            "because nothing on that path reads it — but that is a fact about "
+            "those configs, not about every provider outside the tables. Read "
+            "this one's `get_supported_openai_params` against the pinned "
+            "litellm version, then: if it consults "
+            "`litellm.supports_reasoning` for that knob (however it combines "
+            "the call with name heuristics), add the prefix/knob to "
             "`_SUPPORTS_REASONING_GATED_KNOBS` and set "
             "`model_info: {supports_reasoning: true}` on the entry; if it "
             "advertises the knob unconditionally, add it to "
             "`_UNCONDITIONAL_REASONING_KNOBS`; note the version you checked "
             "either way. Only if it advertises the knob nowhere is dropping it "
             "the answer — there is then no config that makes it take effect."
+        )
+
+
+class TestProviderTablesTrackThePinnedLitellm:
+    """The provider tables above are a reading of litellm source at one version.
+
+    Which providers gate a reasoning knob, on which knob, and whether the gate
+    fails closed or open are all version-specific facts: providers get added,
+    and the ``gemini`` / ``vertex_ai`` omission this guard shipped with in an
+    earlier round is what an un-re-read table looks like. So pin the reading to
+    the image tag and fail the build when they diverge, rather than trusting a
+    comment nobody re-reads on a bump."""
+
+    def test_verified_version_matches_the_image_pin(self):
+        pinned = re.search(
+            r"^FROM\s+ghcr\.io/berriai/litellm:v(?P<version>\S+)\s*$",
+            LITELLM_DOCKERFILE.read_text(),
+            re.MULTILINE,
+        )
+        assert pinned, (
+            f"no `FROM ghcr.io/berriai/litellm:v<version>` line in "
+            f"{LITELLM_DOCKERFILE} — this test cannot tell whether the provider "
+            "tables in tests/config/test_litellm_template.py are still current"
+        )
+        assert pinned.group("version") == _VERIFIED_LITELLM_VERSION, (
+            f"config/litellm/Dockerfile now pins litellm "
+            f"v{pinned.group('version')}, but the reasoning-knob provider "
+            f"tables in this file were read against v{_VERIFIED_LITELLM_VERSION}"
+            ". Re-read `get_supported_openai_params` for each prefix in "
+            "`_SUPPORTS_REASONING_GATED_KNOBS` at the new tag (checking both the "
+            "knobs advertised and whether the gate still fails closed), update "
+            "the line references, then move `_VERIFIED_LITELLM_VERSION`."
         )

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -84,8 +84,8 @@ _REASONING_KNOBS = ("reasoning_effort", "thinking")
 # CLASSIFY BY SHAPE, NOT BY COUNT. A hard count ("nine providers do this") is a
 # claim that rots on every litellm bump and tells you nothing about the entry in
 # front of you. Read the provider's ``get_supported_openai_params`` and ask what
-# it does when the model is ABSENT from LiteLLM's map. Three shapes appear at
-# the pinned version, all of which want ``model_info`` set:
+# it does when the model is ABSENT from LiteLLM's map. Two shapes appear at
+# the pinned version, both of which want ``model_info`` set:
 #
 #   (a) pure gate — the ``supports_reasoning`` call is the only condition, so
 #       an unmapped model fails closed and the knob is dropped in silence.
@@ -156,13 +156,31 @@ _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
 # is not in ``LlmProviders``, so there is no spelling that makes the write key
 # and the read key meet.
 #
-# Nothing in ``litellm_params`` / ``model_info`` fixes these. What can still put
-# the knob on the wire is the provider config's own name heuristics
-# (``anthropic.claude-3-7`` / ``claude-sonnet-4`` / ``claude-opus-4`` /
-# ``deepseek.r1`` / ``gpt-oss`` / Nova 2 on bedrock converse, ``"claude" in
-# model`` on github_copilot) — a property of the model name, not of the config —
-# so the guard fails closed and asks for empirical verification against the
-# ``request_params`` log line rather than pretending a YAML key will do it.
+# ``model_info`` cannot RESCUE these entries. That is not the same claim as "the
+# knob can never reach the wire here", and conflating the two is how this guard
+# would fail a build on a config that already works. Two ways the knob still
+# gets advertised on these prefixes, both of which the predicate must let
+# through:
+#
+#   1. The provider config's own model-NAME heuristics fire before the gate is
+#      consulted at all — ``bedrock`` converse's ``gpt-oss`` / Nova-2 / Claude-4
+#      / ``deepseek.r1`` branches. Those are pure substring tests on a name the
+#      operator writes, so the guard can evaluate them exactly:
+#      ``_HEURISTIC_ADVERTISED_KNOBS`` below. (``github_copilot``'s ``"claude"
+#      in model`` is NOT one of these — it is ANDed with the unreachable gate,
+#      not ORed with it, so a Claude name alone never suffices there.)
+#   2. The bare, provider-stripped model name happens to be a top-level key in
+#      LiteLLM's built-in map — e.g. ``gemini-2.5-pro`` is, with
+#      ``supports_reasoning: true``, so ``model: vertex_ai/gemini-2.5-pro`` puts
+#      the knob on the wire with no ``model_info`` and no config at all. That is
+#      a fact about LiteLLM's map at one version, not about the entry, so it
+#      cannot be derived here — an operator who has SEEN the knob on the wire
+#      records it with ``model_info.egg_wire_verified_knobs`` (below).
+#
+# Absent either, the guard fails closed: no YAML key makes the gate pass, so it
+# asks for the provider's native request shape or for empirical verification
+# against the ``request_params`` log line rather than pretending ``model_info``
+# will do it.
 #
 # Verified at ``_VERIFIED_LITELLM_VERSION``; line numbers are from that tag.
 _GATE_UNREACHABLE_BY_MODEL_INFO: dict[str, tuple[str, ...]] = {
@@ -170,7 +188,10 @@ _GATE_UNREACHABLE_BY_MODEL_INFO: dict[str, tuple[str, ...]] = {
     # — ``supports_reasoning(model)``, no provider
     "vertex_ai/": ("reasoning_effort", "thinking"),
     # llms/github_copilot/chat/transformation.py:122-129 — ``"claude" in model``
-    # AND ``supports_reasoning(model=model.lower())``, no provider
+    # AND ``supports_reasoning(model=model.lower())``, no provider. Both
+    # conjuncts must hold, so the Claude name is not an escape from the gate:
+    # it needs the bare stripped name (``claude-sonnet-4``, not
+    # ``github_copilot/claude-sonnet-4``) to be in LiteLLM's map.
     "github_copilot/": ("reasoning_effort", "thinking"),
     # llms/bedrock/chat/converse_transformation.py:555-575 — provider passed but
     # spelled ``bedrock_converse``. Note also that the ``gpt-oss`` and Nova-2
@@ -178,6 +199,70 @@ _GATE_UNREACHABLE_BY_MODEL_INFO: dict[str, tuple[str, ...]] = {
     # ONLY, so on those name families ``thinking`` is never advertised at all.
     "bedrock/": ("reasoning_effort", "thinking"),
 }
+
+# ``model_info`` key an operator uses to record that they have SEEN a knob on
+# the wire for this route, mapping knob -> the litellm version it was observed
+# at. It is the green path out of ``_GATE_UNREACHABLE_BY_MODEL_INFO`` for the
+# case no static rule can express: the bare model name happening to be in
+# LiteLLM's built-in map (``vertex_ai/gemini-2.5-pro`` today). Empirical proof
+# beats source reading, but it expires — the map moves on a bump, which is why
+# the value is a version and why the guard only honours it at the pinned one.
+#
+# Not accepted by the other two guards on purpose. On a gated-but-reachable
+# provider ``model_info: {supports_reasoning: true}`` is the actual fix and an
+# attestation would just let an entry skip it; on a provider in no table at all
+# the required work is reading that config, and an attestation there would be a
+# way to never do it.
+#
+# ``ModelInfo`` is ``ConfigDict(extra="allow")`` (``litellm/types/router.py``),
+# so LiteLLM carries the key through router init and ignores it.
+_WIRE_VERIFIED_KNOBS_KEY = "egg_wire_verified_knobs"
+
+# Provider prefix -> a predicate mapping a written model string to the knobs
+# that provider advertises on the NAME ALONE, with no ``supports_reasoning``
+# call involved.
+#
+# Only ``bedrock`` (converse) has these. ``converse_transformation.py:555-575``
+# is an ``if``/``elif`` chain whose first two branches short-circuit before any
+# gate, and whose third ORs three Claude-name tests and ``deepseek.r1`` in front
+# of the gate. Note the knob asymmetry the chain creates: on a ``gpt-oss`` or
+# Nova-2 name ``reasoning_effort`` is advertised and ``thinking`` is NOT — and
+# never can be, whatever the config says, because the matching branch returns
+# before the branch that appends it.
+#
+# Verified at ``_VERIFIED_LITELLM_VERSION``.
+_BEDROCK_BOTH_KNOB_NAMES = ("claude-3-7", "claude-sonnet-4", "claude-opus-4", "deepseek.r1")
+
+
+def _is_nova_2_model(model: str) -> bool:
+    """Mirror of ``AmazonConverseConfig._is_nova_2_model``.
+
+    Strips the routing prefix then the regional prefix, exactly as
+    ``llms/bedrock/chat/converse_transformation.py:280-331`` does, before
+    matching the Nova 2 families."""
+    for routing_prefix in ("bedrock/converse/", "bedrock/", "converse/"):
+        if model.startswith(routing_prefix):
+            model = model.removeprefix(routing_prefix)
+            break
+    for region_prefix in ("us.", "eu.", "apac."):
+        if model.startswith(region_prefix):
+            model = model.removeprefix(region_prefix)
+            break
+    return model.startswith("amazon.nova-2-") or model.startswith("nova-2/")
+
+
+def _bedrock_heuristic_knobs(model: str) -> tuple[str, ...]:
+    """Knobs ``AmazonConverseConfig`` advertises for *model* without any gate."""
+    if "gpt-oss" in model:
+        return ("reasoning_effort",)
+    if _is_nova_2_model(model):
+        return ("reasoning_effort",)
+    if any(name in model for name in _BEDROCK_BOTH_KNOB_NAMES):
+        return ("reasoning_effort", "thinking")
+    return ()
+
+
+_HEURISTIC_ADVERTISED_KNOBS = {"bedrock/": _bedrock_heuristic_knobs}
 
 # Provider prefix -> reasoning knobs that provider advertises UNCONDITIONALLY,
 # i.e. with no ``model_info`` needed and no model-map lookup involved.
@@ -188,13 +273,18 @@ _GATE_UNREACHABLE_BY_MODEL_INFO: dict[str, tuple[str, ...]] = {
 # a mapped, non-reasoning deployment name is still gated — so it is deliberately
 # left out rather than half-recorded here. This is not the same category as the
 # two maps above — here ``model_info`` is unnecessary; in the first it is
-# required, in the second it is unreachable. A provider in none of the three is
-# one where the knob is popped silently
-# whatever the config says: ``TogetherAIConfig.get_supported_openai_params``
+# required, in the second it is unreachable.
+#
+# A provider in none of the three tables is a provider nobody has read yet, NOT
+# a provider that is known broken — the tables are a record of what has been
+# checked, not a closed classification of every provider that exists.
+# ``together_ai`` is the one such config that HAS been read and does drop the
+# knob unconditionally: ``TogetherAIConfig.get_supported_openai_params``
 # (``llms/together_ai/chat.py:18-46``) only *subtracts* from
 # ``OpenAIGPTConfig``'s base list, and that base list
 # (``llms/openai/chat/gpt_transformation.py:138-187``) carries no reasoning knob
-# under any condition. Add a prefix here only after reading that provider's
+# under any condition. That is a fact about those two configs, not about the
+# complement. Add a prefix here only after reading that provider's
 # ``get_supported_openai_params`` against the pinned litellm version, and say
 # which version you checked.
 _UNCONDITIONAL_REASONING_KNOBS: dict[str, tuple[str, ...]] = {}
@@ -257,7 +347,7 @@ def _registered_model_key(entry: dict) -> str:
 
     ``Router._create_deployment`` prepends ``custom_llm_provider`` to
     ``litellm_params.model`` **unconditionally** when that field is set
-    (``litellm/router.py:7195-7199``, mirrored at ``:7903-7907``); it does not
+    (``litellm/router.py:7196-7200``, mirrored at ``:7904-7908``); it does not
     check whether the model string already carries the prefix. So this is *not*
     always the same key ``_entry_model`` resolves — see
     ``_model_info_reaches_the_gate``."""
@@ -329,6 +419,31 @@ def _reasoning_knob_offenders(entries: list[dict]) -> list[str]:
     )
 
 
+def _heuristic_knobs(model: str) -> tuple[str, ...]:
+    """Knobs the provider prefixing *model* advertises on the name alone."""
+    for prefix, predicate in _HEURISTIC_ADVERTISED_KNOBS.items():
+        if model.startswith(prefix):
+            return predicate(model)
+    return ()
+
+
+def _wire_verified_knobs(entry: dict) -> tuple[str, ...]:
+    """Knobs this entry attests were seen on the wire at the pinned litellm.
+
+    An attestation naming a different version is ignored — a knob observed at
+    1.85 says nothing about 1.87, since what carries it there is LiteLLM's
+    built-in map rather than anything in this file. That makes the version
+    guard's re-read apply to operator attestations too."""
+    attested = (entry.get("model_info") or {}).get(_WIRE_VERIFIED_KNOBS_KEY) or {}
+    if not isinstance(attested, dict):
+        return ()
+    return tuple(
+        knob
+        for knob, version in attested.items()
+        if knob in _REASONING_KNOBS and str(version) == _VERIFIED_LITELLM_VERSION
+    )
+
+
 def _gate_unreachable_reasoning_knob(entries: list[dict]) -> list[str]:
     """Names of entries whose reasoning knob is gated on
     ``litellm.supports_reasoning`` at a key the entry's ``model_info`` can never
@@ -337,12 +452,28 @@ def _gate_unreachable_reasoning_knob(entries: list[dict]) -> list[str]:
     Separate from ``_reasoning_knob_offenders`` because the remedy differs and
     getting that wrong is how this guard has previously certified the defect it
     exists to catch: there ``model_info`` is the fix, here it is a placebo that
-    *looks* like the fix. Deliberately ignores ``model_info`` for that reason."""
+    *looks* like the fix. ``model_info.supports_reasoning`` is deliberately
+    ignored for that reason.
+
+    But "``model_info`` cannot rescue this" is not "this cannot work", and a
+    guard that fails a build with no way to go green is its own defect. Two
+    exits stay open, both narrow and both checkable:
+
+    * the provider advertises the knob on the model NAME, before consulting the
+      gate (``_HEURISTIC_ADVERTISED_KNOBS`` — bedrock's ``gpt-oss`` / Nova-2 /
+      Claude-4 / ``deepseek.r1`` branches), evaluated here rather than assumed;
+    * the operator has seen the knob on the wire and recorded it at the pinned
+      litellm version (``_WIRE_VERIFIED_KNOBS_KEY``), which is the only way to
+      express "the bare name is in LiteLLM's map" without importing litellm."""
     return sorted(
         entry["model_name"]
         for entry in entries
-        if set(_reasoning_knobs_set(entry))
-        & set(_knobs_for_provider(_entry_model(entry), _GATE_UNREACHABLE_BY_MODEL_INFO))
+        if (
+            set(_reasoning_knobs_set(entry))
+            & set(_knobs_for_provider(_entry_model(entry), _GATE_UNREACHABLE_BY_MODEL_INFO))
+        )
+        - set(_heuristic_knobs(_entry_model(entry)))
+        - set(_wire_verified_knobs(entry))
     )
 
 
@@ -691,7 +822,7 @@ class TestReasoningKnobUnreachableByModelInfo:
     wearing the fix's clothes — so this needs its own guard and its own advice.
 
     The write key is the model string as written
-    (``Router._create_deployment``, ``litellm/router.py:7195-7199``). The read
+    (``Router._create_deployment``, ``litellm/router.py:7196-7200``). The read
     keys are built by ``_get_potential_model_names``
     (``litellm/utils.py:5551-5586``) from the *stripped* model plus whatever
     ``custom_llm_provider`` the gate passed — and when the gate passes none,
@@ -699,11 +830,18 @@ class TestReasoningKnobUnreachableByModelInfo:
     equal a ``vertex_ai/…``-shaped key. ``bedrock`` (converse) passes one, but
     spelled ``bedrock_converse`` while the operator must write ``bedrock/``.
 
-    Telling those operators to add ``model_info`` would be this guard certifying
-    the exact defect it exists to catch, one taxonomy branch over — so the
-    predicate ignores ``model_info`` entirely and the message sends them to the
-    provider's native request shape or to empirical verification against the
-    ``request_params`` log line instead."""
+    Telling those operators to add ``model_info.supports_reasoning`` would be
+    this guard certifying the exact defect it exists to catch, one taxonomy
+    branch over — so the predicate ignores that flag entirely.
+
+    It does NOT ignore the two ways such an entry can genuinely work, because a
+    guard that fails a working config with no path to green is the mirror-image
+    defect: it costs the operator the knob. Bedrock's name heuristics are
+    evaluated (``_HEURISTIC_ADVERTISED_KNOBS``), and an operator who has watched
+    the knob appear in the post-mapping ``request_params`` line can record that
+    at the pinned litellm version (``_WIRE_VERIFIED_KNOBS_KEY``). Neither exit
+    is a free-form opt-out: the first is derived from source, the second names a
+    version and expires when the image moves."""
 
     @pytest.mark.parametrize(
         ("prefix", "knob"),
@@ -755,6 +893,105 @@ class TestReasoningKnobUnreachableByModelInfo:
         assert _reasoning_knob_offenders([gemini]) == []
         assert _gate_unreachable_reasoning_knob([vertex]) == ["v"]
 
+    @pytest.mark.parametrize(
+        ("model", "advertised"),
+        [
+            # `if "gpt-oss" in model` — first branch, no gate, one knob.
+            ("bedrock/openai.gpt-oss-120b", ("reasoning_effort",)),
+            # `elif self._is_nova_2_model(model)` — same, through the regional
+            # and routing prefix stripping the real helper does.
+            ("bedrock/amazon.nova-2-lite-v1:0", ("reasoning_effort",)),
+            ("bedrock/us.amazon.nova-2-pro-preview-20251202-v1:0", ("reasoning_effort",)),
+            # `elif "claude-sonnet-4" in model or ... or supports_reasoning(...)`
+            # — the gate is the last disjunct, so the name alone carries both.
+            ("bedrock/anthropic.claude-sonnet-4-20250514-v1:0", ("reasoning_effort", "thinking")),
+            ("bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0", ("reasoning_effort", "thinking")),
+            ("bedrock/deepseek.r1-v1:0", ("reasoning_effort", "thinking")),
+            # Nova 1 is not Nova 2, and a plain Claude 3.5 name matches nothing.
+            ("bedrock/amazon.nova-pro-v1:0", ()),
+            ("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", ()),
+        ],
+    )
+    def test_name_heuristics_are_evaluated_not_assumed(self, model, advertised):
+        # Failing the build on a config that already works costs the operator
+        # the knob just as surely as certifying a broken one — and bedrock's
+        # heuristics are pure substring tests on a name written right here, so
+        # there is no excuse for guessing at them.
+        for knob in _REASONING_KNOBS:
+            entry = {"model_name": "m", "litellm_params": {"model": model, knob: "high"}}
+            expected = [] if knob in advertised else ["m"]
+            assert _gate_unreachable_reasoning_knob([entry]) == expected
+            # Whichever way it lands, the other two guards stay out of it.
+            assert _reasoning_knob_offenders([entry]) == []
+            assert _unverified_provider_reasoning_knob([entry]) == []
+
+    def test_wire_verified_knob_is_a_green_path(self):
+        # `gemini-2.5-pro` is a top-level key in LiteLLM's built-in map at the
+        # pinned version, so vertex's bare `supports_reasoning(model)` resolves
+        # it and the knob reaches the wire with no `model_info` at all. No
+        # static rule here can know that — the map is not importable from this
+        # process and moves on a bump — so an operator who has seen it on the
+        # `request_params` line records the observation instead.
+        entry = {
+            "model_name": "gemini-2-5-pro",
+            "litellm_params": {"model": "vertex_ai/gemini-2.5-pro", "reasoning_effort": "high"},
+        }
+        assert _gate_unreachable_reasoning_knob([entry]) == ["gemini-2-5-pro"]
+        verified = {
+            **entry,
+            "model_info": {
+                _WIRE_VERIFIED_KNOBS_KEY: {"reasoning_effort": _VERIFIED_LITELLM_VERSION}
+            },
+        }
+        assert _gate_unreachable_reasoning_knob([verified]) == []
+
+    def test_wire_verification_is_per_knob_and_expires_with_the_pin(self):
+        base = {
+            "model_name": "v",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-2.5-pro",
+                "reasoning_effort": "high",
+                "thinking": {"type": "enabled"},
+            },
+        }
+        # Attesting one knob says nothing about the other.
+        one_knob = {
+            **base,
+            "model_info": {
+                _WIRE_VERIFIED_KNOBS_KEY: {"reasoning_effort": _VERIFIED_LITELLM_VERSION}
+            },
+        }
+        assert _gate_unreachable_reasoning_knob([one_knob]) == ["v"]
+        # An observation made against a different litellm is not evidence about
+        # this one: what carries the knob is LiteLLM's map, which the bump moves.
+        stale = {**base, "model_info": {_WIRE_VERIFIED_KNOBS_KEY: {"reasoning_effort": "1.80.0"}}}
+        assert _gate_unreachable_reasoning_knob([stale]) == ["v"]
+        # A malformed attestation is ignored rather than trusted.
+        malformed = {**base, "model_info": {_WIRE_VERIFIED_KNOBS_KEY: ["reasoning_effort"]}}
+        assert _gate_unreachable_reasoning_knob([malformed]) == ["v"]
+
+    def test_wire_verification_is_not_accepted_by_the_other_guards(self):
+        # On a reachable gated provider the real fix exists, so an attestation
+        # must not be a way around setting it; on an unread provider the
+        # required work is reading the config. Honouring it in either place is
+        # how a guard stops guarding.
+        gated = {
+            "model_name": "or",
+            "litellm_params": {"model": "openrouter/x/y", "reasoning_effort": "high"},
+            "model_info": {
+                _WIRE_VERIFIED_KNOBS_KEY: {"reasoning_effort": _VERIFIED_LITELLM_VERSION}
+            },
+        }
+        assert _reasoning_knob_offenders([gated]) == ["or"]
+        unverified = {
+            "model_name": "tog",
+            "litellm_params": {"model": "together_ai/Qwen/Qwen2.5-7B", "reasoning_effort": "high"},
+            "model_info": {
+                _WIRE_VERIFIED_KNOBS_KEY: {"reasoning_effort": _VERIFIED_LITELLM_VERSION}
+            },
+        }
+        assert _unverified_provider_reasoning_knob([unverified]) == ["tog"]
+
     def test_no_reasoning_knob_where_model_info_cannot_reach_the_gate(self):
         offenders = _gate_unreachable_reasoning_knob(_load_model_list())
         assert not offenders, (
@@ -767,12 +1004,21 @@ class TestReasoningKnobUnreachableByModelInfo:
             "`custom_llm_provider` (`vertex_ai`, `github_copilot`) or with a "
             "different one than you can write (`bedrock`, whose converse config "
             "reports `bedrock_converse`), so the flag is filed where nothing "
-            "reads it. What can still carry the knob is the provider config's "
-            "own model-name heuristics, which no YAML key controls. Either use "
-            "the provider's native request shape, or confirm empirically that "
-            "the knob survives — `cost_callback` logs post-mapping "
-            "`request_params` per call, so grep the LiteLLM pod stream for the "
-            "knob on real traffic before trusting it. See "
+            "reads it. Three ways forward, in order of preference: (1) use the "
+            "provider's native request shape, which does not go through the "
+            "param mapper at all; (2) pick a model whose name the provider "
+            "config recognises without the gate — on `bedrock` those are "
+            "`gpt-oss` and Nova 2 (`reasoning_effort` only; `thinking` is never "
+            "advertised on those names), and `claude-3-7` / `claude-sonnet-4` / "
+            "`claude-opus-4` / `deepseek.r1` (both knobs), all of which this "
+            "guard already accepts; (3) if you have SEEN the knob on the wire "
+            "for this route — `cost_callback` logs post-mapping "
+            "`request_params` per call, so grep the LiteLLM pod stream on real "
+            f"traffic — record it as `model_info: {{{_WIRE_VERIFIED_KNOBS_KEY}: "
+            f'{{<knob>: "{_VERIFIED_LITELLM_VERSION}"}}}}` on both paired '
+            "rows. That is an observation, not a guess, and it expires when the "
+            "image pin moves, since what carries the knob there is LiteLLM's "
+            "built-in map rather than anything in this file. See "
             "`_GATE_UNREACHABLE_BY_MODEL_INFO` for the per-provider reason."
         )
 

--- a/tests/config/test_litellm_template.py
+++ b/tests/config/test_litellm_template.py
@@ -34,11 +34,13 @@ LITELLM_DOCKERFILE = REPO_ROOT / "config" / "litellm" / "Dockerfile"
 _ALIAS_SUFFIX = "[1m]"
 
 # The litellm version every provider-config claim in this file was read
-# against. ``test_provider_tables_match_the_pinned_litellm`` fails the build if
-# the image is bumped past it, because which providers gate a reasoning knob —
-# and on what — is version-specific: providers get added, and a gate can flip
-# from fail-closed to fail-open in a patch release. A bump means re-reading the
-# ``get_supported_openai_params`` of each prefix below, then moving this string.
+# against.
+# ``TestProviderTablesTrackThePinnedLitellm::test_verified_version_matches_the_image_pin``
+# fails the build if the image is bumped past it, because which providers gate a
+# reasoning knob — and on what — is version-specific: providers get added, and a
+# gate can flip from fail-closed to fail-open in a patch release. A bump means
+# re-reading the ``get_supported_openai_params`` of each prefix below, then
+# moving this string.
 _VERIFIED_LITELLM_VERSION = "1.86.2"
 
 # The reasoning knobs LiteLLM can silently drop. Both are appended under the
@@ -49,7 +51,8 @@ _VERIFIED_LITELLM_VERSION = "1.86.2"
 _REASONING_KNOBS = ("reasoning_effort", "thinking")
 
 # Provider prefix -> the reasoning knobs that provider's LiteLLM chat config
-# decides to advertise by consulting ``litellm.supports_reasoning(model, …)``.
+# decides to advertise by consulting ``litellm.supports_reasoning(model, …)``,
+# AND whose gate call is reachable by the entry's own ``model_info``.
 #
 # For these prefix/knob combinations ``model_info: {supports_reasoning: true}``
 # on the entry is the thing that makes the knob reach the wire:
@@ -58,6 +61,25 @@ _REASONING_KNOBS = ("reasoning_effort", "thinking")
 # dynamically added deployments at ``:7897-7923``), which is exactly what
 # ``supports_reasoning`` → ``_get_model_info_helper`` reads back
 # (``litellm/utils.py:2775-2781``). Nothing in that path is OpenRouter-specific.
+#
+# MEMBERSHIP CRITERION — BOTH halves, not just the first:
+#
+#   1. the provider's ``get_supported_openai_params`` consults
+#      ``litellm.supports_reasoning`` for that knob, and
+#   2. the gate call passes ``custom_llm_provider``, spelled the same as the
+#      prefix an operator writes in ``litellm_params.model``.
+#
+# (2) is what was silently assumed for several rounds, and it is not free.
+# The router files ``model_info`` under the *written* model string
+# (``custom_llm_provider + "/" + model`` when that field is set, raw ``model``
+# otherwise). Request-time lookup builds its candidate keys from
+# ``custom_llm_provider + "/" + <stripped model>``
+# (``_get_potential_model_names``, ``litellm/utils.py:5551-5586``) — but ONLY
+# when the gate passed one. A gate that calls ``supports_reasoning(model)`` bare
+# gets ``custom_llm_provider=None``, and that branch never prefixes any
+# candidate, so the registered ``openrouter/…``-shaped key is not a candidate at
+# all. Those providers go in ``_GATE_UNREACHABLE_BY_MODEL_INFO`` below — the
+# gate is real, but ``model_info`` cannot satisfy it.
 #
 # CLASSIFY BY SHAPE, NOT BY COUNT. A hard count ("nine providers do this") is a
 # claim that rots on every litellm bump and tells you nothing about the entry in
@@ -68,14 +90,14 @@ _REASONING_KNOBS = ("reasoning_effort", "thinking")
 #   (a) pure gate — the ``supports_reasoning`` call is the only condition, so
 #       an unmapped model fails closed and the knob is dropped in silence.
 #       ``model_info`` is REQUIRED. Most rows below are this shape.
-#   (b) gate AND a name heuristic — ``github_copilot`` advertises the knobs
-#       only for a model whose name contains "claude" *and* which answers the
-#       gate. ``model_info`` is necessary but not sufficient there.
-#   (c) name heuristics OR gate — ``anthropic`` and ``bedrock`` (converse) let
-#       a recognised name (``claude-3-7``, ``claude-sonnet-4``, ``deepseek.r1``,
-#       …) through without consulting the map at all, and fall back to the gate
-#       for every other name. ``model_info`` is what carries those other names;
-#       on a recognised name it is merely redundant.
+#   (b) name heuristics OR gate — ``anthropic`` lets a recognised name
+#       (``claude-3-7-sonnet``, the Claude 4.6/4.7 families) through without
+#       consulting the map at all, and falls back to the gate for every other
+#       name. ``model_info`` is what carries those other names; on a recognised
+#       name it is merely redundant.
+#
+# A third shape — gated, but on a key ``model_info`` cannot reach — is NOT here;
+# see ``_GATE_UNREACHABLE_BY_MODEL_INFO``.
 #
 # The contrast case, and the reason the shape matters more than the call:
 # azure's o-series config calls ``supports_reasoning`` too
@@ -97,12 +119,11 @@ _REASONING_KNOBS = ("reasoning_effort", "thinking")
 # advertise ``reasoning_effort`` at all, so a per-provider tuple would be wrong
 # for them. That is why this maps to knobs rather than to a bare prefix list.
 _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
-    # (a) pure gate, both knobs under one ``if``
+    # (a) pure gate, both knobs under one ``if``; passes ``custom_llm_provider``
     "openrouter/": ("reasoning_effort", "thinking"),  # llms/openrouter/chat/transformation.py:41-48
     "gemini/": ("reasoning_effort", "thinking"),  # llms/gemini/chat/transformation.py:96-98
-    # llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py:328-330
-    "vertex_ai/": ("reasoning_effort", "thinking"),
-    # (a) pure gate, one knob
+    # (a) pure gate, one knob; each passes ``custom_llm_provider`` spelled
+    # exactly as the prefix below (``self.custom_llm_provider`` or a literal)
     "groq/": ("reasoning_effort",),  # llms/groq/chat/transformation.py:107-110
     "xai/": ("reasoning_effort",),  # llms/xai/chat/transformation.py:77-80
     "deepinfra/": ("reasoning_effort",),  # llms/deepinfra/chat/transformation.py:80-84
@@ -112,12 +133,49 @@ _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
     "bedrock_mantle/": ("reasoning_effort",),  # llms/bedrock_mantle/chat/transformation.py:55-59
     "zai/": ("thinking",),  # llms/zai/chat/transformation.py:51-54
     "minimax/": ("thinking",),  # llms/minimax/chat/transformation.py:97
-    # (b) gate AND ``"claude" in model``
-    # llms/github_copilot/chat/transformation.py:122-129
-    "github_copilot/": ("reasoning_effort", "thinking"),
-    # (c) name heuristics OR gate
+    # (b) name heuristics OR gate; gate passes ``custom_llm_provider``
+    # ("anthropic", matching the prefix)
     "anthropic/": ("reasoning_effort", "thinking"),  # llms/anthropic/chat/transformation.py:454-464
-    # llms/bedrock/chat/converse_transformation.py:556-575
+}
+
+# Provider prefix -> reasoning knobs that provider gates on
+# ``litellm.supports_reasoning`` **on a key the entry's own ``model_info`` can
+# never land on**. Half the criterion above holds and the other half does not,
+# which is why these cannot sit in the map above: demanding ``model_info`` here
+# would certify a config that still drops the knob in silence.
+#
+# ``vertex_ai`` and ``github_copilot`` call the gate with no
+# ``custom_llm_provider``, so ``_get_potential_model_names`` takes its
+# ``custom_llm_provider is None`` branch (``litellm/utils.py:5554-5565``) and
+# every candidate key is derived from the bare model string — no candidate can
+# ever equal the ``vertex_ai/…`` / ``github_copilot/…`` key the router
+# registered. ``bedrock`` fails the same way one step further along: the
+# converse config's ``custom_llm_provider`` property returns
+# ``"bedrock_converse"`` (``llms/bedrock/chat/converse_transformation.py:124-126``)
+# while the operator must write the ``bedrock/`` prefix — ``bedrock_converse``
+# is not in ``LlmProviders``, so there is no spelling that makes the write key
+# and the read key meet.
+#
+# Nothing in ``litellm_params`` / ``model_info`` fixes these. What can still put
+# the knob on the wire is the provider config's own name heuristics
+# (``anthropic.claude-3-7`` / ``claude-sonnet-4`` / ``claude-opus-4`` /
+# ``deepseek.r1`` / ``gpt-oss`` / Nova 2 on bedrock converse, ``"claude" in
+# model`` on github_copilot) — a property of the model name, not of the config —
+# so the guard fails closed and asks for empirical verification against the
+# ``request_params`` log line rather than pretending a YAML key will do it.
+#
+# Verified at ``_VERIFIED_LITELLM_VERSION``; line numbers are from that tag.
+_GATE_UNREACHABLE_BY_MODEL_INFO: dict[str, tuple[str, ...]] = {
+    # llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py:328-330
+    # — ``supports_reasoning(model)``, no provider
+    "vertex_ai/": ("reasoning_effort", "thinking"),
+    # llms/github_copilot/chat/transformation.py:122-129 — ``"claude" in model``
+    # AND ``supports_reasoning(model=model.lower())``, no provider
+    "github_copilot/": ("reasoning_effort", "thinking"),
+    # llms/bedrock/chat/converse_transformation.py:555-575 — provider passed but
+    # spelled ``bedrock_converse``. Note also that the ``gpt-oss`` and Nova-2
+    # branches short-circuit the ``elif`` chain and append ``reasoning_effort``
+    # ONLY, so on those name families ``thinking`` is never advertised at all.
     "bedrock/": ("reasoning_effort", "thinking"),
 }
 
@@ -129,8 +187,9 @@ _SUPPORTS_REASONING_GATED_KNOBS: dict[str, tuple[str, ...]] = {
 # deployment name absent from LiteLLM's map) but is *conditionally* fail-open —
 # a mapped, non-reasoning deployment name is still gated — so it is deliberately
 # left out rather than half-recorded here. This is not the same category as the
-# map above — here ``model_info`` is unnecessary, there it is
-# required. A provider in neither map is one where the knob is popped silently
+# two maps above — here ``model_info`` is unnecessary; in the first it is
+# required, in the second it is unreachable. A provider in none of the three is
+# one where the knob is popped silently
 # whatever the config says: ``TogetherAIConfig.get_supported_openai_params``
 # (``llms/together_ai/chat.py:18-46``) only *subtracts* from
 # ``OpenAIGPTConfig``'s base list, and that base list
@@ -217,7 +276,13 @@ def _model_info_reaches_the_gate(entry: dict) -> bool:
     gate looks up ``openrouter/qwen/qwen3-max`` (prefix stripped, then re-added
     once). The flag is written and read at different keys, so
     ``supports_reasoning`` still answers False and the knob is still dropped in
-    silence — with the config now *looking* correct. Spell the provider once."""
+    silence — with the config now *looking* correct. Spell the provider once.
+
+    This models the *entry*-shaped way the two keys diverge. The other way is
+    provider-shaped — a gate that passes no ``custom_llm_provider`` at all, or
+    passes a different one than the operator can write — and no entry can fix
+    that, which is why it lives in ``_GATE_UNREACHABLE_BY_MODEL_INFO`` rather
+    than in this predicate."""
     return _registered_model_key(entry) == _entry_model(entry)
 
 
@@ -242,9 +307,12 @@ def _reasoning_knob_offenders(entries: list[dict]) -> list[str]:
 
     Keyed off ``_SUPPORTS_REASONING_GATED_KNOBS`` rather than a single provider,
     because the gate is not OpenRouter-specific — a range of other provider
-    configs consult the same call, and for all of them ``model_info`` is what
-    satisfies it. Knobs the provider does not gate are not this predicate's
-    business; ``_unverified_provider_reasoning_knob`` has them.
+    configs consult the same call, and for every prefix in that table
+    ``model_info`` is what satisfies it. Knobs the provider does not gate are
+    not this predicate's business (``_unverified_provider_reasoning_knob`` has
+    them), and neither are providers whose gate ``model_info`` cannot reach
+    (``_gate_unreachable_reasoning_knob``) — demanding the flag there would
+    certify a config that still drops the knob.
 
     ``model_info`` only counts when it lands on the key the gate reads
     (``_model_info_reaches_the_gate``): a double-spelled provider registers it
@@ -261,10 +329,26 @@ def _reasoning_knob_offenders(entries: list[dict]) -> list[str]:
     )
 
 
+def _gate_unreachable_reasoning_knob(entries: list[dict]) -> list[str]:
+    """Names of entries whose reasoning knob is gated on
+    ``litellm.supports_reasoning`` at a key the entry's ``model_info`` can never
+    reach — see ``_GATE_UNREACHABLE_BY_MODEL_INFO``.
+
+    Separate from ``_reasoning_knob_offenders`` because the remedy differs and
+    getting that wrong is how this guard has previously certified the defect it
+    exists to catch: there ``model_info`` is the fix, here it is a placebo that
+    *looks* like the fix. Deliberately ignores ``model_info`` for that reason."""
+    return sorted(
+        entry["model_name"]
+        for entry in entries
+        if set(_reasoning_knobs_set(entry))
+        & set(_knobs_for_provider(_entry_model(entry), _GATE_UNREACHABLE_BY_MODEL_INFO))
+    )
+
+
 def _unverified_provider_reasoning_knob(entries: list[dict]) -> list[str]:
     """Names of entries setting a reasoning knob their provider is not known to
-    advertise at all — neither gated on ``supports_reasoning`` nor
-    unconditional.
+    advertise at all — in none of the three tables above.
 
     Deliberately ignores ``model_info``: these providers never consult
     ``litellm.supports_reasoning`` for this knob, so accepting the flag here
@@ -274,6 +358,7 @@ def _unverified_provider_reasoning_knob(entries: list[dict]) -> list[str]:
         for entry in entries
         if set(_reasoning_knobs_set(entry))
         - set(_knobs_for_provider(_entry_model(entry), _SUPPORTS_REASONING_GATED_KNOBS))
+        - set(_knobs_for_provider(_entry_model(entry), _GATE_UNREACHABLE_BY_MODEL_INFO))
         - set(_knobs_for_provider(_entry_model(entry), _UNCONDITIONAL_REASONING_KNOBS))
     )
 
@@ -379,15 +464,23 @@ class TestReasoningKnobIsNotASilentNoop:
 
     The gate is **not** OpenRouter-specific. A range of other provider configs
     consult the same ``litellm.supports_reasoning`` call when deciding whether
-    to advertise a reasoning knob — ``gemini`` and ``vertex_ai`` with exactly
-    OpenRouter's fail-closed shape, ``anthropic`` / ``bedrock`` /
-    ``github_copilot`` in combination with a model-name heuristic — and on all
-    of them ``model_info`` is what satisfies it, because
+    to advertise a reasoning knob — ``gemini`` with exactly OpenRouter's
+    fail-closed shape, ``groq`` / ``xai`` / ``deepinfra`` / ``cerebras`` /
+    ``fireworks_ai`` / ``perplexity`` / ``bedrock_mantle`` on
+    ``reasoning_effort``, ``zai`` / ``minimax`` on ``thinking``, ``anthropic``
+    behind a name heuristic — and on those ``model_info`` satisfies it, because
     ``Router._create_deployment`` registers ``model_info`` into
     ``litellm.model_cost`` under a key built from ``litellm_params``, nothing
     provider-specific. ``_SUPPORTS_REASONING_GATED_KNOBS`` records which knob
-    each of them gates and which shape it is. Providers outside that map get the
-    separate check below, where ``model_info`` genuinely is a placebo."""
+    each of them gates and which shape it is.
+
+    Consulting the gate is necessary but not sufficient for membership: the gate
+    call must also pass a ``custom_llm_provider`` the operator can spell, or the
+    flag is registered under a key the lookup never forms.
+    ``vertex_ai`` / ``github_copilot`` / ``bedrock`` fail that second half and
+    get ``TestReasoningKnobUnreachableByModelInfo`` below; providers in no table
+    at all get ``TestReasoningKnobOnUnverifiedProvider``. In both of those
+    ``model_info`` is a placebo, for different reasons."""
 
     def test_predicate_flags_the_silent_noop(self):
         # A guard that cannot fire is not a guard. Exercise it against the
@@ -478,18 +571,23 @@ class TestReasoningKnobIsNotASilentNoop:
         # One case per (prefix, knob) pair in the table, so a row added without
         # thinking cannot ride in untested — and the per-knob splits (`zai` and
         # `minimax` gate `thinking` only) are exercised rather than assumed.
-        # `model_info` is the fix on every one of them: the registration path
-        # (`Router._create_deployment` -> `litellm.model_cost`) is not
-        # provider-specific.
+        # `model_info` is the fix on every row in THIS table: the registration
+        # path (`Router._create_deployment` -> `litellm.model_cost`) is not
+        # provider-specific, and each of these gates passes a
+        # `custom_llm_provider` matching the prefix, so the key it registers
+        # under is the key the gate reads back. Rows failing that second half
+        # live in `_GATE_UNREACHABLE_BY_MODEL_INFO` and must not appear here.
         bare = {
             "model_name": "m",
             "litellm_params": {"model": f"{prefix}vendor/model", knob: "high"},
         }
         assert _reasoning_knob_offenders([bare]) == ["m"]
         assert _unverified_provider_reasoning_knob([bare]) == []
+        assert _gate_unreachable_reasoning_knob([bare]) == []
         flagged = {**bare, "model_info": {"supports_reasoning": True}}
         assert _reasoning_knob_offenders([flagged]) == []
         assert _unverified_provider_reasoning_knob([flagged]) == []
+        assert _gate_unreachable_reasoning_knob([flagged]) == []
 
     @pytest.mark.parametrize(
         ("prefix", "knob"),
@@ -574,8 +672,10 @@ class TestReasoningKnobIsNotASilentNoop:
             "no-op and the agent runs at the provider's default depth. Add "
             "`model_info: {supports_reasoning: true}` to the entry (it is "
             "registered into the model-cost map under a key built from "
-            "`litellm_params`, so it satisfies the gate on every provider in "
-            "`_SUPPORTS_REASONING_GATED_KNOBS`), or on `openrouter/*` use the "
+            "`litellm_params`, and every provider in "
+            "`_SUPPORTS_REASONING_GATED_KNOBS` passes a matching "
+            "`custom_llm_provider` to the gate, so the flag lands on the key "
+            "the gate reads back), or on `openrouter/*` use the "
             "native `extra_body.reasoning.effort` instead. Pin the flag even "
             "for a model currently in the map: map membership changes under you "
             "on a litellm bump, the config does not. If the entry already "
@@ -585,11 +685,103 @@ class TestReasoningKnobIsNotASilentNoop:
         )
 
 
+class TestReasoningKnobUnreachableByModelInfo:
+    """Where a provider gates the knob on ``litellm.supports_reasoning`` but at
+    a key the entry's own ``model_info`` cannot land on, the flag is a placebo
+    wearing the fix's clothes — so this needs its own guard and its own advice.
+
+    The write key is the model string as written
+    (``Router._create_deployment``, ``litellm/router.py:7195-7199``). The read
+    keys are built by ``_get_potential_model_names``
+    (``litellm/utils.py:5551-5586``) from the *stripped* model plus whatever
+    ``custom_llm_provider`` the gate passed — and when the gate passes none,
+    that function's first branch prefixes nothing, so no candidate can ever
+    equal a ``vertex_ai/…``-shaped key. ``bedrock`` (converse) passes one, but
+    spelled ``bedrock_converse`` while the operator must write ``bedrock/``.
+
+    Telling those operators to add ``model_info`` would be this guard certifying
+    the exact defect it exists to catch, one taxonomy branch over — so the
+    predicate ignores ``model_info`` entirely and the message sends them to the
+    provider's native request shape or to empirical verification against the
+    ``request_params`` log line instead."""
+
+    @pytest.mark.parametrize(
+        ("prefix", "knob"),
+        [
+            (prefix, knob)
+            for prefix, knobs in sorted(_GATE_UNREACHABLE_BY_MODEL_INFO.items())
+            for knob in knobs
+        ],
+    )
+    def test_model_info_does_not_clear_the_flag(self, prefix, knob):
+        # One case per (prefix, knob) pair, so a row cannot be added to the
+        # table without the "model_info doesn't rescue it" property being
+        # exercised — that property is the whole reason the table is separate.
+        entry = {
+            "model_name": "m",
+            "litellm_params": {"model": f"{prefix}vendor/model", knob: "high"},
+        }
+        assert _gate_unreachable_reasoning_knob([entry]) == ["m"]
+        flagged = {**entry, "model_info": {"supports_reasoning": True}}
+        assert _gate_unreachable_reasoning_knob([flagged]) == ["m"]
+        # And it must not be double-reported by the other two guards, whose
+        # advice would be wrong for it.
+        assert _reasoning_knob_offenders([flagged]) == []
+        assert _unverified_provider_reasoning_knob([flagged]) == []
+
+    def test_predicate_ignores_entries_without_a_reasoning_knob(self):
+        assert (
+            _gate_unreachable_reasoning_knob(
+                [{"model_name": "plain", "litellm_params": {"model": "vertex_ai/gemini-3-pro"}}]
+            )
+            == []
+        )
+
+    def test_predicate_ignores_reachable_gated_providers(self):
+        # `gemini/` passes `custom_llm_provider="gemini"` to the gate and
+        # `vertex_ai/` passes nothing — same Google model family, opposite
+        # answers. Pin the pair so a future edit cannot merge the two rows.
+        gemini = {
+            "model_name": "g",
+            "litellm_params": {"model": "gemini/gemini-3-pro", "reasoning_effort": "high"},
+            "model_info": {"supports_reasoning": True},
+        }
+        vertex = {
+            "model_name": "v",
+            "litellm_params": {"model": "vertex_ai/gemini-3-pro", "reasoning_effort": "high"},
+            "model_info": {"supports_reasoning": True},
+        }
+        assert _gate_unreachable_reasoning_knob([gemini]) == []
+        assert _reasoning_knob_offenders([gemini]) == []
+        assert _gate_unreachable_reasoning_knob([vertex]) == ["v"]
+
+    def test_no_reasoning_knob_where_model_info_cannot_reach_the_gate(self):
+        offenders = _gate_unreachable_reasoning_knob(_load_model_list())
+        assert not offenders, (
+            "model_list entries setting `litellm_params.reasoning_effort` (or "
+            "`thinking`) on a provider that gates the knob on "
+            f"`litellm.supports_reasoning` at a key `model_info` cannot reach: "
+            f"{offenders} — do NOT add `model_info: {{supports_reasoning: "
+            "true}}` here. LiteLLM registers it under the model string as "
+            "written, while these gates look the model up with no "
+            "`custom_llm_provider` (`vertex_ai`, `github_copilot`) or with a "
+            "different one than you can write (`bedrock`, whose converse config "
+            "reports `bedrock_converse`), so the flag is filed where nothing "
+            "reads it. What can still carry the knob is the provider config's "
+            "own model-name heuristics, which no YAML key controls. Either use "
+            "the provider's native request shape, or confirm empirically that "
+            "the knob survives — `cost_callback` logs post-mapping "
+            "`request_params` per call, so grep the LiteLLM pod stream for the "
+            "knob on real traffic before trusting it. See "
+            "`_GATE_UNREACHABLE_BY_MODEL_INFO` for the per-provider reason."
+        )
+
+
 class TestReasoningKnobOnUnverifiedProvider:
     """Where a provider does not advertise the knob at all,
     ``model_info.supports_reasoning`` is not the fix — it is not read.
 
-    This is the complement of ``_SUPPORTS_REASONING_GATED_KNOBS``, not "anything
+    This is the complement of the two tables above, not "anything
     that isn't OpenRouter". ``TogetherAIConfig.get_supported_openai_params``
     (``llms/together_ai/chat.py:18-46``) only *subtracts* ``response_format`` /
     tool params from ``OpenAIGPTConfig``'s base list, and that base list carries
@@ -600,16 +792,18 @@ class TestReasoningKnobOnUnverifiedProvider:
     waved over them.
 
     There is no config-shaped fix to assert here, so the guard demands a
-    human-verified entry in one of the two tables instead: someone has to read
+    human-verified entry in one of the three tables instead: someone has to read
     that provider's ``get_supported_openai_params`` against the pinned litellm
-    before the build goes green. The two escape hatches are not interchangeable
-    — a provider that consults ``litellm.supports_reasoning`` at all belongs in
+    before the build goes green. The escape hatches are not interchangeable — a
+    provider that consults ``litellm.supports_reasoning`` at all belongs in
     ``_SUPPORTS_REASONING_GATED_KNOBS`` (where ``model_info`` is then
-    *required*); listing it in ``_UNCONDITIONAL_REASONING_KNOBS`` instead would
-    stop checking it entirely and let the genuine silent no-op through. When in
-    doubt, the gated table is the fail-safe classification.
+    *required*) or, if its gate call cannot see a key ``model_info`` produces,
+    in ``_GATE_UNREACHABLE_BY_MODEL_INFO``; listing it in
+    ``_UNCONDITIONAL_REASONING_KNOBS`` instead would stop checking it entirely
+    and let the genuine silent no-op through. When in doubt, the gated table is
+    the fail-safe classification.
 
-    Being in neither table means "nobody has read this provider's config yet",
+    Being in no table means "nobody has read this provider's config yet",
     not "this provider is broken" — the guard fails closed on ignorance."""
 
     def test_predicate_flags_an_unverified_provider(self):
@@ -676,9 +870,13 @@ class TestReasoningKnobOnUnverifiedProvider:
             "this one's `get_supported_openai_params` against the pinned "
             "litellm version, then: if it consults "
             "`litellm.supports_reasoning` for that knob (however it combines "
-            "the call with name heuristics), add the prefix/knob to "
+            "the call with name heuristics) AND passes a `custom_llm_provider` "
+            "spelled like the prefix you write, add the prefix/knob to "
             "`_SUPPORTS_REASONING_GATED_KNOBS` and set "
             "`model_info: {supports_reasoning: true}` on the entry; if it "
+            "consults the gate but with no `custom_llm_provider` or a "
+            "different one, `model_info` cannot reach it — add the prefix/knob "
+            "to `_GATE_UNREACHABLE_BY_MODEL_INFO` instead; if it "
             "advertises the knob unconditionally, add it to "
             "`_UNCONDITIONAL_REASONING_KNOBS`; note the version you checked "
             "either way. Only if it advertises the knob nowhere is dropping it "
@@ -689,16 +887,26 @@ class TestReasoningKnobOnUnverifiedProvider:
 class TestProviderTablesTrackThePinnedLitellm:
     """The provider tables above are a reading of litellm source at one version.
 
-    Which providers gate a reasoning knob, on which knob, and whether the gate
-    fails closed or open are all version-specific facts: providers get added,
-    and the ``gemini`` / ``vertex_ai`` omission this guard shipped with in an
-    earlier round is what an un-re-read table looks like. So pin the reading to
-    the image tag and fail the build when they diverge, rather than trusting a
-    comment nobody re-reads on a bump."""
+    Which providers gate a reasoning knob, on which knob, whether the gate fails
+    closed or open, and whether the call passes a ``custom_llm_provider`` are all
+    version-specific facts, and providers get added between releases. So pin the
+    reading to the image tag and fail the build when they diverge, rather than
+    trusting a comment nobody re-reads on a bump.
+
+    What this guard does NOT catch is a table that was incomplete when written —
+    the ``gemini`` / ``vertex_ai`` omissions earlier in this PR's review happened
+    *at* the pinned version, with no bump involved, and only a re-read of the
+    source found them. This forces that re-read at the one moment it is
+    guaranteed to be needed; it does not substitute for it."""
 
     def test_verified_version_matches_the_image_pin(self):
+        # Tolerate the shapes a pin legitimately takes — a trailing
+        # `AS <stage>`, and a `@sha256:` digest suffix — so a Dockerfile edit
+        # that keeps the same version gets silence rather than a confusing
+        # "version mismatch: 1.86.2@sha256:…" or a spurious "no FROM line".
         pinned = re.search(
-            r"^FROM\s+ghcr\.io/berriai/litellm:v(?P<version>\S+)\s*$",
+            r"^FROM\s+ghcr\.io/berriai/litellm:v(?P<version>[^\s@]+)"
+            r"(?:@sha256:[0-9a-f]+)?(?:\s+[Aa][Ss]\s+\S+)?\s*$",
             LITELLM_DOCKERFILE.read_text(),
             re.MULTILINE,
         )


### PR DESCRIPTION
> **Stacked on #3611** (base is `egg/litellm-record-request-params`, not `main`). Review that one first; this PR's diff is the two commits' difference. Rebase to `main` once #3611 lands.

## The bug

egg's operator config sets `reasoning_effort: high` in `litellm_params`. Per #3599 that is **the only generation-affecting parameter egg sets anywhere**. It never reaches the wire for the models egg actually routes.

Found while verifying the unresolved question left open in #3599 and #3616. The answer turned out to be worse than the question: `reasoning_effort` isn't *overridden* by a client `thinking` budget, it is *dropped outright*, with or without one.

## Root cause

`OpenrouterConfig.get_supported_openai_params` advertises `reasoning_effort` / `thinking` only when `litellm.supports_reasoning(model)` is true, and that reads LiteLLM's built-in model-cost map. A model **absent** from the map answers `False`, so the gate fails closed — and `drop_params: true` then discards the parameter in a bare `pass`: no exception, no log line.

Absent is the *normal* state for an OpenRouter slug. Verified against the pinned litellm 1.86.2:

| Model | In LiteLLM's map | `supports_reasoning` |
|---|---|---|
| `qwen/qwen3-max` | ✗ | `False` |
| `moonshotai/kimi-k2-thinking` | ✗ | `False` |
| `deepseek/deepseek-r1` | ✓ | `True` |

OpenRouter adds models faster than LiteLLM's map tracks them, so a new slug is unflagged by default and the agent quietly runs at the provider's default reasoning depth. This is the default case, not the exotic one.

## Verification

Driven through a `Router` `model_list` entry on the `anthropic_messages` route (the shape and route the real proxy uses), HTTP mocked at the transport layer:

| Config form | Wire body |
|---|---|
| `litellm_params.reasoning_effort: high` (today) | *absent* ✗ |
| `+ model_info: {supports_reasoning: true}` | `reasoning_effort: high` ✓ |
| `extra_body: {reasoning: {effort: high}}` | `reasoning: {effort: high}` ✓ |
| `drop_params: false` | request **fails**: `UnsupportedParamsError` (HTTP 500) |

Controls run in the same harness: `temperature`, `top_p`, `seed` and the `extra_body` provider pin all reach the wire from `litellm_params` unchanged, so this is specific to `reasoning_effort` and not a general "config doesn't apply" problem.

`drop_params: false` is not a fix at all. Unsupported params do not pass through; they raise
`UnsupportedParamsError` with `status_code=500` (`litellm/utils.py:4082-4085`), so the route 500s
instead of quietly under-reasoning. That flag is also what stops Anthropic-only fields LiteLLM cannot translate (e.g. `thinking`) from 400ing tool-heavy turns, as the template documents. It trades a silent no-op for loud request failures.

## Changes

- **Template** documents the trap and both working forms, and steers the `qwen3-max` example to the `extra_body.reasoning` shape — which bypasses the param mapper entirely and so does not depend on the model map at all. That makes it the more durable of the two for OpenRouter routes.
- **CI guard**: an entry setting `litellm_params.reasoning_effort` without `model_info.supports_reasoning: true` now fails the build. The predicate is unit-tested in both directions, including that the `extra_body.reasoning` form is correctly *not* flagged — a guard that cannot fire is not a guard.
- **Second guard** pins `model_info` across paired bare/`[1m]` rows. It is a sibling of `litellm_params`, so the existing params-parity test never saw it; divergence would mean probe traffic and real traffic run at different reasoning depths.
- **Guide** documents the trap with the verification table.

## The limit of the CI guard, and what covers it

Operator overlays (`~/.config/egg/litellm-models.yaml`) are not in CI, and the models in play — `laguna-s-2.1` — live only there. So the guard protects the committed template and nothing else.

That is why every surface here points at the same runtime check instead: `request_params` from #3611 reports **post-mapping** params, i.e. what the wire carried. If `reasoning_effort` is not on that log line, it did not reach the model, whatever the config file says. The guard prevents the mistake in the repo; the log line catches it everywhere else.

## Upstream

The general defect — `drop_params` discarding caller-specified params in total silence — is fixed separately in the litellm fork (`jwbron/litellm`, branch `drop-params-visibility`): a deduped warning naming the dropped params, model and provider, with 5 tests. Not yet pushed or proposed upstream; say the word. That fix is *not* in the pinned 1.86.2 image, so it does not change egg's runtime here.

## Testing

- 8 tests pass in `tests/config/test_litellm_template.py` (3 new predicate tests + the template assertion + the new `model_info` parity guard).
- 185 pass in `tests/config/`.
- `make lint` clean.

