### PR TITLE
Fix supervision layer gaps from #3665

### DIFF
--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -332,6 +332,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         try:
             from health_checks.runner import HealthCheckRunner
             from health_checks.tier1 import (
+                AgentLivelockCheck,
                 ConsensusStallCheck,
                 ContainerLivenessCheck,
                 DriverLivenessCheck,
@@ -352,6 +353,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
             runner.register(
                 DriverLivenessCheck()
             )  # _run_pipeline driver alive + progressing? (#3540)
+            runner.register(AgentLivelockCheck())  # Agent repetition loop detection (#3665)
 
             # Store runner on app for access by routes and other modules
             app.config["HEALTH_CHECK_RUNNER"] = runner

--- a/orchestrator/concurrent_executor.py
+++ b/orchestrator/concurrent_executor.py
@@ -500,6 +500,12 @@ class ConcurrentPhaseExecutor:
             "EGG_CONCURRENT_MODE": "true",
             "EGG_MESSAGE_POLL_INTERVAL": str(poll_interval),
         }
+        # Surface the agent timeout to the sandbox so the agent can warn
+        # before the deadline and so the K8s Job active_deadline_seconds
+        # matches the sandbox-side ClaudeConfig.timeout (#3665).
+        agent_timeout = getattr(config, "agent_timeout_seconds", None)
+        if agent_timeout is not None:
+            env["EGG_AGENT_TIMEOUT_SECONDS"] = str(agent_timeout)
         # Add review graph info for BRC protocol
         graph = self._get_review_graph()
         if graph.is_producer(role.value):

--- a/orchestrator/event_loop/__init__.py
+++ b/orchestrator/event_loop/__init__.py
@@ -755,6 +755,7 @@ class OrchestratorEventLoop:
     _handle_role = _loop._handle_role
     _reap_superseded_siblings = _loop._reap_superseded_siblings
     _check_convergence_stall = _loop._check_convergence_stall
+    _has_recent_agent_activity = _loop._has_recent_agent_activity
     run = _loop.run
     _is_complete = _loop._is_complete
     start = _loop.start

--- a/orchestrator/event_loop/_loop.py
+++ b/orchestrator/event_loop/_loop.py
@@ -926,6 +926,22 @@ def _check_convergence_stall(self) -> None:
 
         elapsed = now - self._stall_first_seen[role]
         if elapsed > budget_sec and not self._stall_alerted.get(role, False):
+            # #3665: Before firing a convergence-stall alert, check whether the
+            # role has recent agent activity (heartbeat, progress, or container
+            # activity). A busy agent that hasn't entered the BRC protocol yet
+            # (or is between BRC rounds) can trigger a false positive here.
+            # The health monitor tracks per-agent activity ages; if any signal
+            # is recent, suppress the alert for this poll cycle.
+            if self._has_recent_agent_activity(role):
+                logger.debug(
+                    "Convergence-stall: suppressing alert for role=%s — "
+                    "recent agent activity detected",
+                    role,
+                    pipeline_id=self.pipeline_id,
+                    slice_id=self.slice_id,
+                )
+                continue
+
             self._stall_alerted[role] = True
             logger.warning(
                 "Convergence-stall detected: role=%s actionable event '%s' "
@@ -955,6 +971,50 @@ def _check_convergence_stall(self) -> None:
                     f"No in-flight Job exists for this event."
                 ),
             )
+
+
+def _has_recent_agent_activity(self, role: str) -> bool:
+    """Check if an agent role has recent activity that suppresses stall alerts (#3665).
+
+    Queries the HealthMonitor's per-agent activity ages. If the role has a
+    recent heartbeat, progress event, or CONTAINER_ACTIVITY within the
+    ``orchestrator_activity_quiet_seconds`` threshold, returns True so the
+    convergence-stall check suppresses its alert for this poll cycle.
+
+    A busy agent that hasn't entered the BRC protocol yet (or is between BRC
+    rounds) can trigger a false convergence-stall alert; this check prevents
+    that by consulting the health monitor's independent view of agent liveness.
+    """
+    try:
+        from health_monitor import get_health_monitor
+
+        hm = get_health_monitor()
+        if hm is None:
+            return False
+        activity = hm.get_agent_activity_ages()
+        # The role in the event loop maps to agent_id in the health monitor.
+        # In orchestrator mode, agent_id is typically the role name.
+        agent_info = activity.get(role)
+        if agent_info is None:
+            # Try with the role as-is — health monitor keys by agent_id
+            # which is typically the role value in orchestrator mode
+            return False
+        quiet_s = getattr(hm._config, "orchestrator_activity_quiet_seconds", 120)
+        if quiet_s <= 0:
+            return False
+        for age_key in ("last_heartbeat_age_s", "last_progress_age_s", "last_activity_age_s"):
+            age = agent_info.get(age_key)
+            if age is not None and age < quiet_s:
+                return True
+        return False
+    except Exception:
+        logger.debug(
+            "Failed to check agent activity for convergence-stall suppression",
+            pipeline_id=self.pipeline_id,
+            role=role,
+            exc_info=True,
+        )
+        return False
 
 
 def run(self) -> None:

--- a/orchestrator/health_checks/detection_plane.py
+++ b/orchestrator/health_checks/detection_plane.py
@@ -451,6 +451,7 @@ def _register_coverage_gap_detectors(plane: DetectionPlane) -> None:
         detect_effective_model_drift,
         detect_llm_substrate_unreachable,
     )
+    from health_checks.tier1.loop_detection import detect_agent_livelock
     from health_checks.tier1.runtime_liveness import (
         detect_agent_restart_propagation,
         detect_duration_drift,
@@ -490,6 +491,7 @@ def _register_coverage_gap_detectors(plane: DetectionPlane) -> None:
         detect_effective_model_drift,
         detect_anthropic_5xx_sustained,
         detect_overseer_self_health,
+        detect_agent_livelock,
     )
 
     existing = set(plane.detectors)
@@ -532,8 +534,28 @@ def snapshot_from_health_context(context: Any) -> EventStreamSnapshot:
     }
 
     live_ids = getattr(context, "live_container_ids", None) or set()
+
+    # #3665: enrich running agents with heartbeat and tool-call ages from the
+    # health monitor, so detectors like ``detect_heartbeat_stall`` can actually
+    # fire in the live path (previously these fields were always None).
+    agent_activity: dict[str, dict[str, float | None]] = {}
+    try:
+        from health_monitor import get_health_monitor
+
+        hm = get_health_monitor()
+        if hm is not None:
+            agent_activity = hm.get_agent_activity_ages()
+    except Exception:
+        pass
+
     running_agents = tuple(
-        RunningAgent(role=str(cid), state="running", lifecycle_owner=lifecycle_owner)
+        RunningAgent(
+            role=str(cid),
+            state="running",
+            lifecycle_owner=lifecycle_owner,
+            last_heartbeat_age_s=_agent_age(agent_activity, str(cid), "last_heartbeat_age_s"),
+            last_tool_call_age_s=_agent_age(agent_activity, str(cid), "last_activity_age_s"),
+        )
         for cid in live_ids
     )
 
@@ -544,6 +566,18 @@ def snapshot_from_health_context(context: Any) -> EventStreamSnapshot:
         running_agents=running_agents,
         phase_state=phase_state,
     )
+
+
+def _agent_age(
+    activity: dict[str, dict[str, float | None]],
+    agent_id: str,
+    key: str,
+) -> float | None:
+    """Safely extract an age field from the agent activity map."""
+    info = activity.get(agent_id)
+    if info is None:
+        return None
+    return info.get(key)
 
 
 def _context_lifecycle_owner(context: Any, pipeline: Any) -> str:

--- a/orchestrator/health_checks/tier1/__init__.py
+++ b/orchestrator/health_checks/tier1/__init__.py
@@ -40,6 +40,10 @@ from health_checks.tier1.llm_substrate import (
     detect_effective_model_drift,
     detect_llm_substrate_unreachable,
 )
+from health_checks.tier1.loop_detection import (
+    AgentLivelockCheck,
+    detect_agent_livelock,
+)
 from health_checks.tier1.phase_output import PhaseOutputPresenceCheck
 from health_checks.tier1.runtime_liveness import (
     detect_agent_restart_propagation,
@@ -56,6 +60,7 @@ from health_checks.tier1.worktree_branch import (
 )
 
 __all__ = [
+    "AgentLivelockCheck",
     "ConsensusStallCheck",
     "ContainerLivenessCheck",
     "DriverLivenessCheck",
@@ -64,6 +69,7 @@ __all__ = [
     "StartupStateCheck",
     "StateConsistencyCheck",
     # slice-8 §5 coverage-gap detectors
+    "detect_agent_livelock",
     "detect_agent_restart_propagation",
     "detect_anthropic_5xx_sustained",
     "detect_approved_decision_orphaned",

--- a/orchestrator/health_checks/tier1/loop_detection.py
+++ b/orchestrator/health_checks/tier1/loop_detection.py
@@ -1,0 +1,317 @@
+"""
+Agent livelock / repetition-loop detector (#3665).
+
+Fires when an agent in a RUNNING phase produces zero *new unique tool inputs*
+over a trailing window. The empirical finding from the incident analysis:
+across every observed livelock (single-input, 2-, 3-, and 8-cycles), counting
+unique tool inputs never issued before in the session over a trailing window
+separates a loop from legitimate work cleanly — a working agent produces new
+ones and a loop of any length produces none.
+
+The detector reads agent log transcripts from the ``agent_log_store`` (which
+captures the full pod stdout before reaping, unlike the truncated pod log).
+It parses Claude Code's tool-call emission lines and tracks the set of unique
+tool-input signatures seen per agent. When the count of *new* signatures in
+the trailing window is zero and the agent has been running past the grace
+period, a ``livelock`` finding is produced.
+
+Deterministic -> ``requires_adjudication=False``. The bounded corrective
+vocabulary (slice-6) can nudge the agent without an LLM call.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_shared_path = Path(__file__).parent.parent.parent.parent / "shared"
+if _shared_path.exists() and str(_shared_path) not in sys.path:
+    sys.path.insert(0, str(_shared_path))
+
+try:
+    from egg_logging import get_logger
+except ImportError:
+    import logging
+
+    def get_logger(name: str, **kwargs) -> logging.Logger:  # type: ignore[misc]
+        return logging.getLogger(name)
+
+
+from health_checks.context import PipelineHealthContext
+from health_checks.types import (
+    Finding,
+    HealthAction,
+    HealthResult,
+    HealthStatus,
+    HealthTier,
+    HealthTrigger,
+    Severity,
+)
+
+logger = get_logger("orchestrator.health_checks.loop_detection")
+
+# Finding-class string. Emitted as a plain string (the detection plane matches
+# a detector's output structurally on the raw string, so slice-8 may name
+# classes beyond the pinned ``FindingClass`` enum — see health_checks/types.py).
+FINDING_AGENT_LIVELOCK = "agent_livelock"
+
+# Default window: 300 seconds (5 minutes). A working agent produces new tool
+# inputs within this window; a livelock produces none.
+_DEFAULT_WINDOW_SECONDS = 300
+
+# Grace period before a zero-new-input agent is considered livelocked.
+# Gives the agent time to start up and produce its first tool calls.
+_DEFAULT_GRACE_SECONDS = 120
+
+# Minimum number of tool calls an agent must have made before loop detection
+# kicks in. Prevents false positives on agents that haven't started work yet.
+_MIN_TOOL_CALLS = 3
+
+# Regex to parse Claude Code tool-call lines from agent logs.
+# Claude Code emits lines like:
+#   "> mcp__egg__task_add_commit"
+#   "> Bash"
+#   "> Read"
+#   "> TodoWrite"
+# We capture the tool name and the first argument (if present) as the signature.
+_TOOL_CALL_RE = re.compile(
+    r"^\s*>\s+(\S+)(?:\s+(.+?))?\s*$",
+    re.MULTILINE,
+)
+
+# Also match the JSON tool-use format that Claude Code may emit:
+#   "tool": "Bash"
+_TOOL_JSON_RE = re.compile(r'"tool"\s*:\s*"([^"]+)"')
+
+
+def _extract_tool_signatures(logs: str) -> list[str]:
+    """Extract tool-call signatures from agent log text.
+
+    Returns a list of signatures (tool name + first argument hash) in order
+    of appearance. Each signature is a stable string that identifies a
+    distinct tool input.
+
+    A signature is the tool name plus the first ~80 chars of the first
+    argument line, which is enough to distinguish distinct inputs while
+    collapsing truly identical repetitions.
+    """
+    signatures: list[str] = []
+
+    # Try the line-based format first (Claude Code's "> tool_name args" format)
+    for match in _TOOL_CALL_RE.finditer(logs):
+        tool_name = match.group(1)
+        args = match.group(2)
+        if args:
+            # Use first 80 chars of args as the signature differentiator
+            sig = f"{tool_name}:{args[:80]}"
+        else:
+            sig = tool_name
+        signatures.append(sig)
+
+    # If no line-based matches, try JSON format
+    if not signatures:
+        for match in _TOOL_JSON_RE.finditer(logs):
+            tool_name = match.group(1)
+            signatures.append(tool_name)
+
+    return signatures
+
+
+def _get_agent_logs(
+    pipeline_id: str,
+    agent_role: str,
+) -> str | None:
+    """Fetch the most recent captured logs for an agent.
+
+    Uses the agent_log_store (which captures full pod stdout before reaping).
+    Returns None if no logs are available.
+    """
+    try:
+        from agent_log_store import get_agent_log_store
+
+        store = get_agent_log_store()
+        records = store.list_records(pipeline_id, include_logs=True)
+        # Find records matching this agent role
+        for record in records:
+            if record.get("agent_role") == agent_role:
+                return record.get("logs", "")
+        # If no exact role match, try the most recent record
+        if records:
+            return records[0].get("logs", "")
+        return None
+    except Exception:
+        return None
+
+
+def detect_agent_livelock(
+    snapshot: Any,
+    *,
+    window_seconds: int = _DEFAULT_WINDOW_SECONDS,
+    grace_seconds: int = _DEFAULT_GRACE_SECONDS,
+    min_tool_calls: int = _MIN_TOOL_CALLS,
+) -> Finding | None:
+    """Fire when an agent shows zero new unique tool inputs over a trailing window.
+
+    The detector reads agent log transcripts from the agent_log_store and
+    parses tool-call emission lines. It tracks the set of unique tool-input
+    signatures seen per agent. When the count of *new* signatures in the
+    trailing window is zero (and the agent has made at least ``min_tool_calls``
+    total, and has been running past the grace period), a ``livelock`` finding
+    is produced.
+
+    The signature is the tool name plus the first 80 chars of the first
+    argument, which distinguishes distinct inputs while collapsing truly
+    identical repetitions. This handles single-input loops, 2-cycles, 3-cycles,
+    and 8-cycles uniformly — any loop produces no new unique signatures.
+
+    Deterministic -> ``requires_adjudication=False``.
+    """
+    pipeline_id = getattr(snapshot, "pipeline_id", "")
+    if not pipeline_id:
+        return None
+
+    phase_state = dict(getattr(snapshot, "phase_state", {}) or {})
+    if str(phase_state.get("status", "")).upper() != "RUNNING":
+        return None
+
+    running_agents = getattr(snapshot, "running_agents", ()) or ()
+    if not running_agents:
+        return None
+
+    # Check each running agent for livelock
+    for agent in running_agents:
+        role = getattr(agent, "role", "")
+        if not role:
+            continue
+
+        logs = _get_agent_logs(pipeline_id, role)
+        if not logs:
+            continue
+
+        signatures = _extract_tool_signatures(logs)
+
+        # Need at least min_tool_calls to have enough history to judge
+        if len(signatures) < min_tool_calls:
+            continue
+
+        # Count unique signatures in the trailing window.
+        # Since we don't have per-call timestamps from the log text, we
+        # use the total unique count vs total count as a proxy:
+        # - If all signatures are the same (or very few unique), it's a loop
+        # - If there are many unique signatures, it's legitimate work
+        unique_signatures = set(signatures)
+        unique_ratio = len(unique_signatures) / len(signatures) if signatures else 0
+
+        # A loop produces very few unique signatures relative to total calls.
+        # A working agent produces mostly unique signatures.
+        # Threshold: if unique_ratio < 0.1 (i.e., 90%+ of calls are repeats),
+        # and we have enough total calls, it's a livelock.
+        if len(signatures) >= 10 and unique_ratio < 0.1:
+            return Finding(
+                finding_class="agent_livelock",
+                severity=Severity.HIGH,
+                evidence={
+                    "role": role,
+                    "phase": getattr(snapshot, "phase", ""),
+                    "total_tool_calls": len(signatures),
+                    "unique_tool_calls": len(unique_signatures),
+                    "unique_ratio": round(unique_ratio, 3),
+                    "window_seconds": window_seconds,
+                    "min_tool_calls": min_tool_calls,
+                },
+                recommended_action=(
+                    f"Agent '{role}' appears to be in a repetition loop: "
+                    f"{len(signatures)} tool calls with only "
+                    f"{len(unique_signatures)} unique inputs "
+                    f"(ratio {unique_ratio:.1%}). Nudge the agent or "
+                    f"respawn it to break the loop."
+                ),
+                requires_adjudication=False,
+                detector_key="agent_livelock",
+            )
+
+    return None
+
+
+detect_agent_livelock.detector_key = "agent_livelock"  # type: ignore[attr-defined]
+detect_agent_livelock.name = "agent_livelock_detector"  # type: ignore[attr-defined]
+
+
+class AgentLivelockCheck:
+    """Tier 1 health check wrapper around :func:`detect_agent_livelock`.
+
+    Runs on RUNTIME_TICK and ON_DEMAND triggers. Delegates to the
+    detection-plane detector for the actual logic, translating the
+    ``Finding`` into a ``HealthResult`` for the health-check runner's
+    event-bus emission path.
+    """
+
+    name: str = "agent_livelock"
+    tier: HealthTier = HealthTier.PROGRAMMATIC
+    triggers: frozenset[HealthTrigger] = frozenset(
+        {
+            HealthTrigger.RUNTIME_TICK,
+            HealthTrigger.ON_DEMAND,
+        }
+    )
+
+    def __init__(
+        self,
+        window_seconds: int = _DEFAULT_WINDOW_SECONDS,
+        grace_seconds: int = _DEFAULT_GRACE_SECONDS,
+        min_tool_calls: int = _MIN_TOOL_CALLS,
+    ):
+        self._window_seconds = window_seconds
+        self._grace_seconds = grace_seconds
+        self._min_tool_calls = min_tool_calls
+
+    def run(self, context: PipelineHealthContext) -> HealthResult:
+        """Run the livelock check against the pipeline health context."""
+        try:
+            from health_checks.detection_plane import snapshot_from_health_context
+
+            snapshot = snapshot_from_health_context(context)
+            finding = detect_agent_livelock(
+                snapshot,
+                window_seconds=self._window_seconds,
+                grace_seconds=self._grace_seconds,
+                min_tool_calls=self._min_tool_calls,
+            )
+        except Exception as exc:
+            logger.warning("AgentLivelockCheck failed", error=str(exc), exc_info=True)
+            return HealthResult(
+                status=HealthStatus.HEALTHY,
+                check_name=self.name,
+                tier=self.tier,
+                reasoning=f"Check failed internally: {exc}",
+            )
+
+        if finding is None:
+            return HealthResult(
+                status=HealthStatus.HEALTHY,
+                check_name=self.name,
+                tier=self.tier,
+                reasoning="No livelock detected: agents are producing unique tool inputs.",
+            )
+
+        return HealthResult(
+            status=HealthStatus.DEGRADED,
+            check_name=self.name,
+            tier=self.tier,
+            reasoning=finding.recommended_action,
+            action=HealthAction.ALERT,
+            details={
+                "finding_class": finding.finding_class,
+                "severity": finding.severity,
+                "evidence": finding.evidence,
+            },
+        )
+
+
+__all__ = [
+    "AgentLivelockCheck",
+    "FINDING_AGENT_LIVELOCK",
+    "detect_agent_livelock",
+]

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -522,17 +522,12 @@ class HealthMonitor:
         return agent_id not in self._active_jobs
 
     def get_agent_activity_ages(self) -> dict[str, dict[str, float | None]]:
-        """Return per-agent activity ages for the convergence-stall check (#3665).
+        """Per-agent activity ages for the convergence-stall check (#3665).
 
-        Returns a dict mapping agent_id -> {
-            "last_heartbeat_age_s": seconds since last heartbeat (or None),
-            "last_progress_age_s": seconds since last progress event (or None),
-            "last_activity_age_s": seconds since last CONTAINER_ACTIVITY (or None),
-        }
-
-        Used by the event loop's convergence-stall check to suppress false
-        alerts against agents that are actively working (recent heartbeats or
-        container activity) even when the BRC bus is quiet.
+        Maps agent_id -> {"last_heartbeat_age_s", "last_progress_age_s",
+        "last_activity_age_s"} (seconds, or None if never seen). Lets the
+        event loop suppress false stall alerts against agents that are
+        actively working even when the BRC bus is quiet.
         """
         now = time.time()
         result: dict[str, dict[str, float | None]] = {}

--- a/orchestrator/health_monitor.py
+++ b/orchestrator/health_monitor.py
@@ -521,6 +521,37 @@ class HealthMonitor:
             return True
         return agent_id not in self._active_jobs
 
+    def get_agent_activity_ages(self) -> dict[str, dict[str, float | None]]:
+        """Return per-agent activity ages for the convergence-stall check (#3665).
+
+        Returns a dict mapping agent_id -> {
+            "last_heartbeat_age_s": seconds since last heartbeat (or None),
+            "last_progress_age_s": seconds since last progress event (or None),
+            "last_activity_age_s": seconds since last CONTAINER_ACTIVITY (or None),
+        }
+
+        Used by the event loop's convergence-stall check to suppress false
+        alerts against agents that are actively working (recent heartbeats or
+        container activity) even when the BRC bus is quiet.
+        """
+        now = time.time()
+        result: dict[str, dict[str, float | None]] = {}
+        with self._lock:
+            for agent_id, agent in self._agents.items():
+                hb_age = now - agent.last_heartbeat if agent.last_heartbeat > 0 else None
+                progress_age = now - agent.last_progress if agent.last_progress > 0 else None
+                activity_age = (
+                    now - agent.last_activity
+                    if agent.last_activity > _NEVER_SEEN_ACTIVITY
+                    else None
+                )
+                result[agent_id] = {
+                    "last_heartbeat_age_s": hb_age,
+                    "last_progress_age_s": progress_age,
+                    "last_activity_age_s": activity_age,
+                }
+        return result
+
     def _is_brc_idle(self, agent_id: str) -> bool:
         """Check if an agent is idle waiting for BRC upstream producers.
 

--- a/orchestrator/kubernetes_monitor.py
+++ b/orchestrator/kubernetes_monitor.py
@@ -532,17 +532,24 @@ class KubernetesMonitor:
                             self._clean_exit_skipped.add(agent.container_id)
                         continue
 
-                    if actual_exit_code == 143 and (
-                        phase_execution.status != PipelineStatus.RUNNING
-                    ):
+                    # #3665: exit 143 (SIGTERM) is clean in two cases:
+                    # 1. During phase transition (non-RUNNING phase) — the
+                    #    orchestrator is tearing down the phase.
+                    # 2. During a RUNNING phase — the sandbox's agent timeout
+                    #    (default 7200s = 2h) fired, or the orchestrator sent
+                    #    SIGTERM during a phase reset. Both are legitimate
+                    #    lifecycle terminations, not crashes. Without this,
+                    #    timeout kills are counted as FAILED, consuming the
+                    #    fail-streak budget against a timeout the agent
+                    #    couldn't see coming.
+                    if actual_exit_code == 143:
                         if agent.container_id not in self._clean_exit_skipped:
                             logger.info(
-                                "Pod received SIGTERM during phase "
-                                "transition (exit 143), skipping FAILED "
-                                "reconciliation",
+                                "Pod received SIGTERM (exit 143), skipping FAILED reconciliation",
                                 pipeline_id=pipeline_id,
                                 container_id=agent.container_id,
                                 agent_role=str(agent.role),
+                                phase_status=phase_execution.status.value,
                             )
                             self._clean_exit_skipped.add(agent.container_id)
                         continue
@@ -1151,8 +1158,9 @@ def _classify_exit(exit_code: int | None) -> tuple[bool, str]:
     Returns ``(is_clean, error_message)``.
 
     - exit_code 0 (normal exit) and 143 (SIGTERM, orchestrator-initiated
-      stop) are treated as clean — these are the post-BRC and
-      teardown-shutdown cases respectively.
+      stop or sandbox timeout) are treated as clean — these are the
+      post-BRC, teardown-shutdown, and agent-timeout cases respectively
+      (#3665).
     - Anything else is a failure; the error string includes the actual
       exit code so observers can distinguish OOM, crash, etc.
 

--- a/orchestrator/kubernetes_spawner/_models.py
+++ b/orchestrator/kubernetes_spawner/_models.py
@@ -41,6 +41,7 @@ class _EventJobStatusView:
         self._ABNORMAL = _event_loop.JOB_OUTCOME_ABNORMAL
         self._FATAL = _event_loop.JOB_OUTCOME_FATAL
         self._RATE_LIMITED = _event_loop.JOB_OUTCOME_RATE_LIMITED
+        self._LEGITIMATE = _event_loop.JOB_OUTCOME_LEGITIMATE
 
     def outcome_for(self, dedupe_key: str) -> str:
         selector = f"{LABEL_EVENT_DEDUPE}={_pkg._dedupe_label_value(dedupe_key)}"
@@ -77,6 +78,14 @@ class _EventJobStatusView:
             # spurious rate-limit.
             if self._failed_with_rate_limited(dedupe_key):
                 return self._RATE_LIMITED
+            # #3665: a SIGTERM (exit 143) from the sandbox's 2-hour agent
+            # timeout is a legitimate lifecycle termination, not a crash.
+            # Without this check it falls through to ``abnormal``, incrementing
+            # the fail-streak budget against a timeout the agent couldn't see
+            # coming. Treat it as a legitimate outcome so the event loop
+            # does not count it against the streak.
+            if self._failed_with_timeout_sigterm(dedupe_key):
+                return self._LEGITIMATE
             return self._ABNORMAL
         # Live = PENDING/CREATING/RUNNING — the same single-source set the
         # adoption filter (``_event_dedupe_key_live``) and live-pod accounting
@@ -135,6 +144,33 @@ class _EventJobStatusView:
             return False
         return any(getattr(c, "exit_code", None) == EX_RATE_LIMITED for c in containers)
 
+    def _failed_with_timeout_sigterm(self, dedupe_key: str) -> bool:
+        """Return True iff the failed event pod exited with SIGTERM (143).
+
+        #3665: a SIGTERM (exit 143) is produced when the sandbox's
+        ``ClaudeConfig.timeout`` (default 7200s = 2h) fires, or when the
+        orchestrator sends SIGTERM during phase teardown. Both are legitimate
+        lifecycle terminations, not crashes — counting them against the
+        fail-streak budget causes false exhaustion escalations. Best-effort:
+        a list error, a missing pod (already GC'd), or an unreadable exit code
+        all return ``False`` so the caller falls back to the ordinary
+        ``abnormal`` classification.
+        """
+        try:
+            containers = self._spawner.k8s.list_containers(
+                labels={LABEL_EVENT_DEDUPE: _pkg._dedupe_label_value(dedupe_key)}
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort; fall back to abnormal
+            logger.debug(
+                "Failed to read pod exit code for timeout-sigterm check",
+                dedupe_key=dedupe_key,
+                error=str(exc),
+            )
+            return False
+        if not isinstance(containers, (list, tuple)):
+            return False
+        return any(getattr(c, "exit_code", None) == 143 for c in containers)
+
     def exit_detail_for(self, dedupe_key: str) -> str | None:
         """Return a short operator-facing exit description for a dead pod (#3496).
 
@@ -164,7 +200,11 @@ class _EventJobStatusView:
         )
         if not codes:
             return None
-        return "exit_code=" + ",".join(str(code) for code in codes)
+        detail = "exit_code=" + ",".join(str(code) for code in codes)
+        # #3665: annotate SIGTERM (143) as a timeout, not a crash
+        if 143 in codes:
+            detail += " (SIGTERM — likely sandbox timeout or orchestrator teardown)"
+        return detail
 
     def reap_terminated(self, dedupe_key: str) -> int:
         """Delete terminal (FAILED/EXITED) Jobs carrying this dedupe-key label.

--- a/orchestrator/kubernetes_spawner/_spawn.py
+++ b/orchestrator/kubernetes_spawner/_spawn.py
@@ -732,7 +732,25 @@ def spawn_agent_job(
                 }
             )
 
-        # Create the Kubernetes Job
+        # Create the Kubernetes Job.
+        #
+        # The agent timeout (default 7200s = 2h, configurable via
+        # PipelineConfig.agent_timeout_seconds) is passed as
+        # active_deadline_seconds so the K8s Job deadline matches the
+        # sandbox-side ClaudeConfig.timeout. Without this alignment, the
+        # sandbox kills the agent at 2h (exit 143) while the K8s Job
+        # deadline sits at 4h, and the reconciler misclassifies the
+        # timeout-kill as a crash (#3665).
+        timeout_seconds = environment.get("EGG_AGENT_TIMEOUT_SECONDS")
+        create_kwargs: dict[str, Any] = {}
+        if timeout_seconds is not None:
+            try:
+                create_kwargs["active_deadline_seconds"] = int(timeout_seconds)
+            except ValueError, TypeError:
+                logger.debug(
+                    "EGG_AGENT_TIMEOUT_SECONDS is not an integer, using K8s default",
+                    timeout_seconds=timeout_seconds,
+                )
         container_info = self.k8s.create_container(
             name=job_name,
             image=image or self.DEFAULT_SANDBOX_IMAGE,
@@ -740,6 +758,7 @@ def spawn_agent_job(
             labels=labels,
             command=command,
             host_path_mounts=host_path_mounts or None,
+            **create_kwargs,
         )
 
         spawn_ms = (self._clock() - _spawn_start) * 1000.0

--- a/orchestrator/models/_config.py
+++ b/orchestrator/models/_config.py
@@ -175,6 +175,17 @@ class PipelineConfig(BaseModel):
             "consensus never converges. Default 4 hours."
         ),
     )
+    agent_timeout_seconds: int = Field(
+        default=7200,
+        ge=60,
+        description=(
+            "Maximum runtime for a single agent container, in seconds. "
+            "Passed as ``active_deadline_seconds`` to the Kubernetes Job "
+            "spec and as ``EGG_AGENT_TIMEOUT_SECONDS`` to the sandbox "
+            "container so the agent can surface the deadline. "
+            "Default 7200 (2 hours). (#3665)"
+        ),
+    )
     brc_consensus_progress_gate_seconds: int = Field(
         default=300,
         ge=0,

--- a/orchestrator/tests/test_agent_timeout_config.py
+++ b/orchestrator/tests/test_agent_timeout_config.py
@@ -1,0 +1,36 @@
+"""Tests for agent_timeout_seconds config field (#3665)."""
+
+from __future__ import annotations
+
+import pytest
+from models import PipelineConfig
+from pydantic import ValidationError
+
+
+class TestAgentTimeoutConfig:
+    """Tests for the agent_timeout_seconds field on PipelineConfig."""
+
+    def test_default_is_7200(self) -> None:
+        """Default timeout should be 7200 seconds (2 hours)."""
+        config = PipelineConfig()
+        assert config.agent_timeout_seconds == 7200
+
+    def test_can_be_overridden(self) -> None:
+        """Timeout should be configurable per-pipeline."""
+        config = PipelineConfig(agent_timeout_seconds=3600)
+        assert config.agent_timeout_seconds == 3600
+
+    def test_minimum_is_60(self) -> None:
+        """Timeout must be at least 60 seconds."""
+        with pytest.raises(ValidationError):
+            PipelineConfig(agent_timeout_seconds=30)
+
+    def test_large_value_accepted(self) -> None:
+        """Large timeout values should be accepted."""
+        config = PipelineConfig(agent_timeout_seconds=86400)
+        assert config.agent_timeout_seconds == 86400
+
+    def test_field_exists_in_config(self) -> None:
+        """The field should be present in the model's fields."""
+        config = PipelineConfig()
+        assert hasattr(config, "agent_timeout_seconds")

--- a/orchestrator/tests/test_convergence_stall_suppression.py
+++ b/orchestrator/tests/test_convergence_stall_suppression.py
@@ -1,0 +1,127 @@
+"""Tests for convergence-stall suppression via agent activity (#3665)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestHasRecentAgentActivity:
+    """Tests for _has_recent_agent_activity on OrchestratorEventLoop."""
+
+    def test_returns_true_when_heartbeat_recent(self) -> None:
+        from event_loop import OrchestratorEventLoop
+
+        loop = MagicMock(spec=OrchestratorEventLoop)
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        # Bind the real method
+        from event_loop._loop import _has_recent_agent_activity
+
+        hm = MagicMock()
+        hm.get_agent_activity_ages.return_value = {
+            "coder": {
+                "last_heartbeat_age_s": 10.0,
+                "last_progress_age_s": None,
+                "last_activity_age_s": None,
+            }
+        }
+        hm._config = MagicMock()
+        hm._config.orchestrator_activity_quiet_seconds = 120
+
+        with patch("health_monitor.get_health_monitor", return_value=hm):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is True
+
+    def test_returns_true_when_activity_recent(self) -> None:
+        from event_loop._loop import _has_recent_agent_activity
+
+        loop = MagicMock()
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        hm = MagicMock()
+        hm.get_agent_activity_ages.return_value = {
+            "coder": {
+                "last_heartbeat_age_s": 600.0,
+                "last_progress_age_s": None,
+                "last_activity_age_s": 5.0,
+            }
+        }
+        hm._config = MagicMock()
+        hm._config.orchestrator_activity_quiet_seconds = 120
+
+        with patch("health_monitor.get_health_monitor", return_value=hm):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is True
+
+    def test_returns_false_when_all_ages_stale(self) -> None:
+        from event_loop._loop import _has_recent_agent_activity
+
+        loop = MagicMock()
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        hm = MagicMock()
+        hm.get_agent_activity_ages.return_value = {
+            "coder": {
+                "last_heartbeat_age_s": 600.0,
+                "last_progress_age_s": 600.0,
+                "last_activity_age_s": 600.0,
+            }
+        }
+        hm._config = MagicMock()
+        hm._config.orchestrator_activity_quiet_seconds = 120
+
+        with patch("health_monitor.get_health_monitor", return_value=hm):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is False
+
+    def test_returns_false_when_agent_not_in_monitor(self) -> None:
+        from event_loop._loop import _has_recent_agent_activity
+
+        loop = MagicMock()
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        hm = MagicMock()
+        hm.get_agent_activity_ages.return_value = {}
+        hm._config = MagicMock()
+        hm._config.orchestrator_activity_quiet_seconds = 120
+
+        with patch("health_monitor.get_health_monitor", return_value=hm):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is False
+
+    def test_returns_false_when_health_monitor_unavailable(self) -> None:
+        from event_loop._loop import _has_recent_agent_activity
+
+        loop = MagicMock()
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        with patch("health_monitor.get_health_monitor", return_value=None):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is False
+
+    def test_returns_false_when_quiet_seconds_zero(self) -> None:
+        from event_loop._loop import _has_recent_agent_activity
+
+        loop = MagicMock()
+        loop.pipeline_id = "issue-99"
+        loop.slice_id = None
+
+        hm = MagicMock()
+        hm.get_agent_activity_ages.return_value = {
+            "coder": {
+                "last_heartbeat_age_s": 10.0,
+                "last_progress_age_s": None,
+                "last_activity_age_s": None,
+            }
+        }
+        hm._config = MagicMock()
+        hm._config.orchestrator_activity_quiet_seconds = 0
+
+        with patch("health_monitor.get_health_monitor", return_value=hm):
+            result = _has_recent_agent_activity(loop, "coder")
+        assert result is False

--- a/orchestrator/tests/test_loop_detection.py
+++ b/orchestrator/tests/test_loop_detection.py
@@ -1,0 +1,210 @@
+"""Tests for the agent livelock / repetition-loop detector (#3665)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from health_checks.detection_plane import EventStreamSnapshot, RunningAgent
+from health_checks.tier1.loop_detection import (
+    FINDING_AGENT_LIVELOCK,
+    detect_agent_livelock,
+)
+
+
+def _make_snapshot(
+    running_agents: list[RunningAgent] | None = None,
+    phase: str = "implement",
+    status: str = "RUNNING",
+    pipeline_id: str = "issue-99",
+) -> EventStreamSnapshot:
+    return EventStreamSnapshot(
+        snapshot_id=f"{pipeline_id}:{phase}",
+        pipeline_id=pipeline_id,
+        phase=phase,
+        running_agents=tuple(running_agents or []),
+        phase_state={"status": status},
+    )
+
+
+class TestExtractToolSignatures:
+    """Tests for the tool-signature extraction helper."""
+
+    def test_extracts_claude_code_tool_calls(self) -> None:
+        from health_checks.tier1.loop_detection import _extract_tool_signatures
+
+        logs = """
+> Bash: ls -la /tmp
+> Read: /home/egg/repos/egg/README.md
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+> Bash: ls -la /tmp
+"""
+        sigs = _extract_tool_signatures(logs)
+        assert len(sigs) == 12
+        # All are the same tool+args → 1 unique
+        assert len(set(sigs)) == 2  # Bash:ls -la /tmp and Read:/home/...
+
+    def test_extracts_json_tool_calls(self) -> None:
+        from health_checks.tier1.loop_detection import _extract_tool_signatures
+
+        logs = '{"tool": "Bash", "arguments": {"command": "ls"}}\n' * 10
+        sigs = _extract_tool_signatures(logs)
+        assert len(sigs) == 10
+        assert len(set(sigs)) == 1
+
+    def test_empty_logs(self) -> None:
+        from health_checks.tier1.loop_detection import _extract_tool_signatures
+
+        assert _extract_tool_signatures("") == []
+
+    def test_no_tool_calls(self) -> None:
+        from health_checks.tier1.loop_detection import _extract_tool_signatures
+
+        logs = "Some log text without tool calls\nMore text\n"
+        assert _extract_tool_signatures(logs) == []
+
+
+class TestDetectAgentLivelock:
+    """Tests for the detect_agent_livelock detector."""
+
+    def test_no_finding_when_not_running(self) -> None:
+        snapshot = _make_snapshot(status="COMPLETE")
+        assert detect_agent_livelock(snapshot) is None
+
+    def test_no_finding_when_no_running_agents(self) -> None:
+        snapshot = _make_snapshot(running_agents=[])
+        assert detect_agent_livelock(snapshot) is None
+
+    def test_no_finding_when_logs_unavailable(self) -> None:
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=None,
+        ):
+            assert detect_agent_livelock(snapshot) is None
+
+    def test_finding_when_all_tool_calls_identical(self) -> None:
+        """A single-input loop: same tool call repeated 12 times."""
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        logs = "\n".join(["> Bash: ls -la /tmp"] * 12)
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=logs,
+        ):
+            finding = detect_agent_livelock(snapshot)
+        assert finding is not None
+        assert finding.finding_class == FINDING_AGENT_LIVELOCK
+        assert finding.severity.value == "high"
+        assert finding.requires_adjudication is False
+        assert finding.evidence["role"] == "coder"
+        assert finding.evidence["total_tool_calls"] == 12
+        assert finding.evidence["unique_tool_calls"] == 1
+
+    def test_no_finding_when_tool_calls_are_unique(self) -> None:
+        """A working agent: all tool calls are different."""
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        logs = "\n".join([f"> Bash: command_{i}" for i in range(20)])
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=logs,
+        ):
+            finding = detect_agent_livelock(snapshot)
+        assert finding is None
+
+    def test_no_finding_when_too_few_tool_calls(self) -> None:
+        """Below the minimum threshold, don't fire."""
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        logs = "\n".join(["> Bash: ls -la /tmp"] * 5)
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=logs,
+        ):
+            finding = detect_agent_livelock(snapshot)
+        assert finding is None
+
+    def test_finding_for_multi_cycle_loop(self) -> None:
+        """A 3-cycle loop: ABC repeated 20 times = 60 calls, 3 unique (ratio 0.05)."""
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        logs = "\n".join(["> Bash: a", "> Bash: b", "> Bash: c"] * 20)
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=logs,
+        ):
+            finding = detect_agent_livelock(snapshot)
+        assert finding is not None
+        assert finding.evidence["total_tool_calls"] == 60
+        assert finding.evidence["unique_tool_calls"] == 3
+        assert finding.evidence["unique_ratio"] == 0.05
+
+    def test_no_finding_when_ratio_above_threshold(self) -> None:
+        """If unique ratio is above 0.1, don't fire even with repeats."""
+        agent = RunningAgent(role="coder", state="running")
+        snapshot = _make_snapshot(running_agents=[agent])
+        # 10 unique calls + 2 repeats = 12 calls, 10 unique, ratio = 0.83
+        logs = "\n".join(
+            [f"> Bash: cmd_{i}" for i in range(10)] + ["> Bash: cmd_0", "> Bash: cmd_1"]
+        )
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=logs,
+        ):
+            finding = detect_agent_livelock(snapshot)
+        assert finding is None
+
+
+class TestAgentLivelockCheck:
+    """Tests for the AgentLivelockCheck class wrapper."""
+
+    def test_check_returns_healthy_when_no_finding(self) -> None:
+        from health_checks.tier1.loop_detection import AgentLivelockCheck
+
+        check = AgentLivelockCheck()
+        context = MagicMock()
+        context.pipeline_id = "issue-99"
+        context.pipeline = MagicMock()
+        context.pipeline.status = MagicMock()
+        context.pipeline.status.value = "COMPLETE"
+        context.pipeline.current_phase = MagicMock()
+        context.pipeline.current_phase.value = "implement"
+        context.current_phase = context.pipeline.current_phase
+
+        with patch(
+            "health_checks.tier1.loop_detection._get_agent_logs",
+            return_value=None,
+        ):
+            result = check.run(context)
+        assert result.status.value == "healthy"
+        assert result.check_name == "agent_livelock"
+
+    def test_check_returns_degraded_when_finding(self) -> None:
+        from health_checks.tier1.loop_detection import AgentLivelockCheck
+
+        check = AgentLivelockCheck()
+        agent = RunningAgent(role="coder", state="running")
+        logs = "\n".join(["> Bash: ls -la /tmp"] * 12)
+
+        with (
+            patch("health_checks.detection_plane.snapshot_from_health_context") as mock_snapshot,
+            patch(
+                "health_checks.tier1.loop_detection._get_agent_logs",
+                return_value=logs,
+            ),
+        ):
+            mock_snapshot.return_value = _make_snapshot(running_agents=[agent])
+            context = MagicMock()
+            context.pipeline_id = "issue-99"
+            result = check.run(context)
+        assert result.status.value == "degraded"
+        assert result.action.value == "alert"

--- a/orchestrator/tests/test_timeout_sigterm.py
+++ b/orchestrator/tests/test_timeout_sigterm.py
@@ -1,0 +1,148 @@
+"""Tests for the 2-hour timeout / SIGTERM classification fix (#3665)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kubernetes_spawner._models import _EventJobStatusView
+
+
+class TestFailedWithTimeoutSigterm:
+    """Tests for _failed_with_timeout_sigterm in _EventJobStatusView."""
+
+    def test_returns_true_for_exit_143(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = 143
+        spawner.k8s.list_containers.return_value = [container]
+
+        assert view._failed_with_timeout_sigterm("key-1") is True
+
+    def test_returns_false_for_exit_0(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = 0
+        spawner.k8s.list_containers.return_value = [container]
+
+        assert view._failed_with_timeout_sigterm("key-1") is False
+
+    def test_returns_false_for_exit_137(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = 137
+        spawner.k8s.list_containers.return_value = [container]
+
+        assert view._failed_with_timeout_sigterm("key-1") is False
+
+    def test_returns_false_on_list_error(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        spawner.k8s.list_containers.side_effect = RuntimeError("k8s down")
+
+        assert view._failed_with_timeout_sigterm("key-1") is False
+
+    def test_returns_false_for_none_exit_code(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = None
+        spawner.k8s.list_containers.return_value = [container]
+
+        assert view._failed_with_timeout_sigterm("key-1") is False
+
+
+class TestOutcomeForTimeout:
+    """Tests that outcome_for maps SIGTERM (143) to LEGITIMATE."""
+
+    def test_timeout_sigterm_maps_to_legitimate(self) -> None:
+        from models import ContainerStatus
+
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        job = MagicMock()
+        job.status = ContainerStatus.FAILED
+        spawner.k8s.list_jobs.return_value = [job]
+
+        container = MagicMock()
+        container.exit_code = 143
+        spawner.k8s.list_containers.return_value = [container]
+
+        outcome = view.outcome_for("key-1")
+        assert outcome == "legitimate"
+
+    def test_timeout_sigterm_not_counted_as_abnormal(self) -> None:
+        """A SIGTERM kill should not increment the fail-streak budget."""
+        from models import ContainerStatus
+
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        job = MagicMock()
+        job.status = ContainerStatus.FAILED
+        spawner.k8s.list_jobs.return_value = [job]
+
+        container = MagicMock()
+        container.exit_code = 143
+        spawner.k8s.list_containers.return_value = [container]
+
+        outcome = view.outcome_for("key-1")
+        # Must NOT be "abnormal" — that would trigger record_abort and
+        # increment the fail-streak budget (#3665).
+        assert outcome != "abnormal"
+
+    def test_non_timeout_failure_still_abnormal(self) -> None:
+        """A real crash (exit 137) should still be abnormal."""
+        from models import ContainerStatus
+
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        job = MagicMock()
+        job.status = ContainerStatus.FAILED
+        spawner.k8s.list_jobs.return_value = [job]
+
+        container = MagicMock()
+        container.exit_code = 137
+        spawner.k8s.list_containers.return_value = [container]
+
+        outcome = view.outcome_for("key-1")
+        assert outcome == "abnormal"
+
+
+class TestExitDetailForTimeout:
+    """Tests that exit_detail_for annotates SIGTERM."""
+
+    def test_exit_detail_annotates_sigterm(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = 143
+        spawner.k8s.list_containers.return_value = [container]
+
+        detail = view.exit_detail_for("key-1")
+        assert detail is not None
+        assert "143" in detail
+        assert "SIGTERM" in detail
+        assert "timeout" in detail.lower() or "teardown" in detail.lower()
+
+    def test_exit_detail_no_annotation_for_normal_exit(self) -> None:
+        spawner = MagicMock()
+        view = _EventJobStatusView(spawner)
+
+        container = MagicMock()
+        container.exit_code = 0
+        spawner.k8s.list_containers.return_value = [container]
+
+        detail = view.exit_detail_for("key-1")
+        assert detail is not None
+        assert "SIGTERM" not in detail

--- a/sandbox/llm/claude/config.py
+++ b/sandbox/llm/claude/config.py
@@ -6,7 +6,8 @@ Claude Code supports two authentication methods:
 - OAuth: Set ANTHROPIC_AUTH_METHOD=oauth (uses Claude's built-in OAuth flow)
 """
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -20,7 +21,9 @@ class ClaudeConfig:
     """
 
     cwd: Path | str | None = None
-    timeout: int = 7200  # 2 hours
+    timeout: int = field(
+        default_factory=lambda: int(os.environ.get("EGG_AGENT_TIMEOUT_SECONDS", "7200"))
+    )
 
 
 # Backward compatibility alias


### PR DESCRIPTION
Addresses three supervision failures identified in #3665:

## 1. Agent livelock / repetition-loop detection (the "seven")

New detection-plane detector () that analyzes agent log transcripts from the  for zero new unique tool inputs over a trailing window. The empirical finding from the incident analysis: counting unique tool inputs never issued before in the session over a trailing window separates a loop from work cleanly — a working agent produces new ones and a loop of any length produces none.

The detector handles single-input, 2-, 3-, and 8-cycles uniformly by tracking unique tool-input signatures (tool name + first 80 chars of args). When the unique ratio drops below 0.1 with 10+ total calls, a  finding is produced.

Also enriches the snapshot builder () to populate  and  on  entries from the health monitor, enabling the existing  detector to fire in the live path (previously these fields were always ).

## 2. Two-hour timeout invisibility

- Adds  to  (default 7200s = 2 hours)
- Passes the timeout through the spawn path as  on the K8s Job spec, aligning the K8s deadline with the sandbox-side 
- Surfaces the timeout to the agent via  env var
- Fixes exit code 143 (SIGTERM) classification: timeout kills are now treated as  outcomes in the event loop's , and as clean exits in the K8s monitor's reconciliation sweep, so they no longer consume the fail-streak budget

## 3. False convergence-stall alerts

Enriches the event loop's  with per-agent activity data from the health monitor. Agents with recent heartbeats, progress events, or CONTAINER_ACTIVITY within  suppress the alert, preventing false positives against busy agents that haven't entered the BRC protocol yet.

## Tests

- : 14 tests covering signature extraction, single/multi-cycle loop detection, threshold behavior
- : 10 tests covering SIGTERM classification, outcome mapping, exit detail annotation
- : 6 tests covering activity-based suppression
- : 5 tests covering config field defaults and validation