### PR TITLE
Make the two host-dependent orchestrator tests hermetic (#3670)

### DIFF
--- a/orchestrator/routes/health.py
+++ b/orchestrator/routes/health.py
@@ -43,11 +43,23 @@ _health_tracker = HealthTracker()
 def _probe_state_store() -> tuple[bool, str]:
     """Request-context-aware shim around :func:`probe_state_store_at`.
 
-    Retained at this import path so callers/tests that patch
-    ``routes.health._probe_state_store`` continue to work. The
-    kubelet-probe path no longer calls this directly — the BG thread in
-    :mod:`state_store_probe` does — but several wedge-propagation tests
-    (``test_state_store_wedge_propagation.py``) exercise it as a unit.
+    **Test-only as of #3670.** This shim has no production callers and
+    nothing patches ``routes.health._probe_state_store`` (the earlier
+    docstring claimed both; a repo-wide grep finds neither). The
+    kubelet-probe path reads the cached snapshot the BG thread in
+    :mod:`state_store_probe` populates, and that thread resolves its own
+    base path via ``_resolve_base_path()`` rather than calling here. What
+    remains are the two wedge-propagation unit tests in
+    ``test_state_store_wedge_propagation.py``, which drive this entirely
+    through a patched ``routes.get_repo_path``.
+
+    Consequence for anyone restoring a production caller: ``get_repo_path``
+    is no longer request-context-bound. Since #2903 it falls back to
+    ``EGG_REPO_PATH`` / CWD instead of raising, so calling this outside a
+    request context probes whatever directory the process happens to be in
+    and can report it wedged. The ``except`` below is a real guard, but it
+    only catches resolution *failures* — it does not make a no-context call
+    correct.
 
     Returns the aggregate ``(healthy, summary)`` pair from
     :func:`probe_state_store_at`. The per-repo detail is dropped here;

--- a/orchestrator/tests/test_per_slice_brc_commit.py
+++ b/orchestrator/tests/test_per_slice_brc_commit.py
@@ -951,12 +951,21 @@ class TestGatewayAllowlistCompatibility:
         it is typically a symlink into the developer's home, so
         realpath lands outside the allowlist and the assertion fails
         for a reason that says nothing about drift.  Stub realpath down
-        to lexical normalization for the duration of the call: the
-        allowlist policy — the thing this test is about — still runs
-        for real, and ``abspath`` keeps collapsing ``..`` so a
-        traversal-shaped constant would still be rejected.  Same seam
-        the gateway's own allowlist tests neutralize
-        (``gateway/tests/test_git_validation.py``).
+        to lexical normalization for the duration of the call.
+
+        The stub *reproduces* production semantics rather than
+        neutralizing a security control: in the deployed topology
+        ``/home/egg/.egg-worktrees`` is a volume mount point
+        (``k8s/overlays/local/patches/gateway-volumes.yaml:26-27``,
+        ``k8s/overlays/local/patches/orchestrator-volumes.yaml:58``;
+        the orchestrator base backs it with the ``home`` emptyDir),
+        never a symlink — so ``realpath`` is the identity function
+        exactly where the gateway actually calls
+        ``validate_repo_path``.  The allowlist policy — the thing this
+        test is about — still runs for real, and ``abspath`` keeps
+        collapsing ``..`` so a traversal-shaped constant would still
+        be rejected.  Same seam the gateway's own allowlist tests
+        neutralize (``gateway/tests/test_git_validation.py``).
         """
         import os
 

--- a/orchestrator/tests/test_per_slice_brc_commit.py
+++ b/orchestrator/tests/test_per_slice_brc_commit.py
@@ -930,7 +930,7 @@ class TestGatewayAllowlistCompatibility:
             f"got {repo_path!r}, expected prefix {str(fake_base)!r}"
         )
 
-    def test_production_worktree_base_dir_lies_within_gateway_allowlist(self):
+    def test_production_worktree_base_dir_lies_within_gateway_allowlist(self, monkeypatch):
         """Pin the contract between orchestrator and gateway.
 
         ``WORKTREE_BASE_DIR`` is where the slice-BRC temp worktree
@@ -941,10 +941,30 @@ class TestGatewayAllowlistCompatibility:
         (orchestrator-side path move OR gateway-side allowlist tweak)
         trips the regression instead of silently passing against a
         stale hardcoded prefix.
+
+        Hermeticity (#3670): ``validate_repo_path`` resolves the
+        candidate through ``os.path.realpath`` before prefix-matching,
+        which is a deliberate anti-traversal measure but makes the
+        result a property of the *host* filesystem rather than of the
+        two constants under test.  In the container
+        ``/home/egg/.egg-worktrees`` is a real directory; on a dev host
+        it is typically a symlink into the developer's home, so
+        realpath lands outside the allowlist and the assertion fails
+        for a reason that says nothing about drift.  Stub realpath down
+        to lexical normalization for the duration of the call: the
+        allowlist policy — the thing this test is about — still runs
+        for real, and ``abspath`` keeps collapsing ``..`` so a
+        traversal-shaped constant would still be rejected.  Same seam
+        the gateway's own allowlist tests neutralize
+        (``gateway/tests/test_git_validation.py``).
         """
+        import os
+
         from routes.pipelines import WORKTREE_BASE_DIR
 
         from gateway.git_client import validate_repo_path
+
+        monkeypatch.setattr(os.path, "realpath", os.path.abspath)
 
         candidate = str(WORKTREE_BASE_DIR / "egg-slice-brc-pipeline-x-slice-y-abc" / "wt")
         ok, error = validate_repo_path(candidate)

--- a/orchestrator/tests/test_state_store_wedge_propagation.py
+++ b/orchestrator/tests/test_state_store_wedge_propagation.py
@@ -378,6 +378,19 @@ class TestHealthEndpointReflectsStateStoreFailure:
         git repo, so the probe reported it wedged and the test failed
         (#3670).
 
+        Note what this does *not* pin any more.  The old test's stated
+        contract — "calling the probe outside a Flask request context
+        must be treated as a configuration issue, not a wedge" — is
+        now not merely unpinned but **false**: post-#2903 the
+        no-context call resolves to ``EGG_REPO_PATH`` / CWD and can
+        report that directory wedged.  That is safe only because
+        ``_probe_state_store`` has no production callers (the kubelet
+        path reads the BG probe cache, and that thread resolves its
+        base path via ``state_store_probe._resolve_base_path()``,
+        which is env-only and returns ``None`` when ``EGG_REPO_PATH``
+        is unset).  Anyone restoring a production caller must re-check
+        that assumption.
+
         The guard in ``_probe_state_store`` is still live and still
         worth pinning, so raise from ``get_repo_path`` explicitly
         rather than depending on a call site that no longer raises.

--- a/orchestrator/tests/test_state_store_wedge_propagation.py
+++ b/orchestrator/tests/test_state_store_wedge_propagation.py
@@ -362,14 +362,33 @@ class TestHealthEndpointReflectsStateStoreFailure:
         assert healthy is True
         assert "probe-skipped" in status
 
-    def test_probe_skipped_when_request_context_missing(self):
-        """Calling the probe outside a Flask request context must be
-        treated as a configuration issue, not a wedge."""
+    def test_probe_skipped_when_repo_path_resolution_fails(self):
+        """A repo-path resolution failure must be treated as a
+        configuration issue, not a wedge.
+
+        Was ``test_probe_skipped_when_request_context_missing``: it
+        relied on ``get_repo_path`` raising ``RuntimeError`` when it
+        touched ``request`` with no Flask app pushed, and asserted the
+        probe swallowed it.  #2903 deliberately made ``get_repo_path``
+        safe outside a request context — it now falls back to
+        ``EGG_REPO_PATH`` / CWD — so the no-context call stopped
+        raising and the probe instead ran against whatever directory
+        pytest was invoked from.  In the container that is a non-repo
+        path and the test passed by accident; on a dev host CWD *is* a
+        git repo, so the probe reported it wedged and the test failed
+        (#3670).
+
+        The guard in ``_probe_state_store`` is still live and still
+        worth pinning, so raise from ``get_repo_path`` explicitly
+        rather than depending on a call site that no longer raises.
+        """
         from routes.health import _probe_state_store
 
-        # No Flask app pushed → get_repo_path raises RuntimeError when
-        # it touches `request`.  Probe should swallow and report skipped.
-        healthy, status = _probe_state_store()
+        with patch(
+            "routes.get_repo_path",
+            side_effect=RuntimeError("Working outside of request context."),
+        ):
+            healthy, status = _probe_state_store()
 
         assert healthy is True
         assert "probe-skipped" in status


### PR DESCRIPTION
Fixes #3670.

Both failures were **non-hermetic tests**, not missing production behaviour. Neither is papered over with a skip, and no `requires_container` marker was needed: both tests now run and pass everywhere.

## `test_production_worktree_base_dir_lies_within_gateway_allowlist`

The contract under test (`WORKTREE_BASE_DIR` must be covered by the gateway's `ALLOWED_REPO_PATHS`) is a relation between two literal constants, but the test asserts it through `validate_repo_path`, which resolves the candidate via `os.path.realpath` before prefix-matching. That resolution is a deliberate anti-traversal measure, but it makes the result a property of the *host* filesystem rather than of the two constants: in the container `/home/egg/.egg-worktrees` is a real directory, while on a dev host it is typically a symlink into the developer's home, so realpath lands outside the allowlist and the assertion fails for a reason that says nothing about drift.

Fix: stub `realpath` down to lexical normalization for the duration of the call — the same seam the gateway's own allowlist tests already neutralize (`gateway/tests/test_git_validation.py`). The allowlist policy itself still runs for real. Verified the test keeps its teeth:

| candidate | result |
|---|---|
| `/home/egg/.egg-worktrees/x/wt` | accepted |
| `/home/egg/.egg-elsewhere/x/wt` (drift on either side) | rejected |
| `/home/egg/.egg-worktrees/../../etc/wt` (traversal) | rejected — `abspath` still collapses `..` |

## `test_probe_skipped_when_request_context_missing` → `test_probe_skipped_when_repo_path_resolution_fails`

Per the issue, I checked whether `_probe_state_store` actually honours the graceful-degradation contract before blaming the test. It does — the guard is live at `orchestrator/routes/health.py:59`:

```python
try:
    base_path = get_repo_path()
except Exception as exc:
    return True, f"probe-skipped: {exc}"
```

What broke is the test's *trigger*. It relied on `get_repo_path()` raising `RuntimeError` when it touched `request` with no Flask app pushed. #2903 (da94da1a9) deliberately made `get_repo_path` safe outside a request context — it now falls back to `EGG_REPO_PATH` / CWD — so the no-context call stopped raising and the probe instead ran against whatever directory pytest was invoked from:

- container / CI: CWD is not a git repo → `probe-skipped` → passed **by accident**;
- dev host: CWD *is* a git repo → the probe reaches `/home/egg/.egg-state`, hits `PermissionError`, and reports `1/1 repos wedged` → failed.

Fix: raise from `get_repo_path` explicitly rather than depending on a call site that no longer raises, and rename the test to say what it actually pins. The guard is still worth pinning; only the way the test reached it was stale.

**Not a code bug.** `_probe_state_store` has no production callers left (the kubelet path reads the BG probe cache, and that thread resolves its base path via `_resolve_base_path()`, which returns `None` unless `EGG_REPO_PATH` is set), so the CWD fallback never reaches a live probe.

## Verification

`pytest orchestrator/tests -q` on a Fedora Asahi dev host (off-container), clean `origin/main` @ c1844f0fa:

| | result |
|---|---|
| before | **2 failed, 8771 passed**, 8 skipped, 1 xfailed |
| after | **8773 passed, 0 failed**, 8 skipped, 1 xfailed |

In-container: both files run in `egg-sandbox:latest` with `/home/egg/.egg-worktrees` present as a real directory → **13 passed** with this change. Running the same container against the pre-change files, the allowlist test passes but `test_probe_skipped_when_request_context_missing` **fails there too** whenever CWD is a git repo — which is what makes it non-hermetic rather than container-only.

`make lint` clean on both files (pre-commit ruff + ruff format passed).
